### PR TITLE
Publish images on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,23 @@ jobs:
         run: |
           cd backend
           npm test || true
+      - name: Extract versions
+        id: vars
+        run: |
+          BACKEND_VERSION=$(jq -r .version backend/package.json)
+          echo "BACKEND_VERSION=$BACKEND_VERSION" >> "$GITHUB_OUTPUT"
+          echo "FRONTEND_VERSION=0.1.0" >> "$GITHUB_OUTPUT"
       - name: Build Docker images
-        run: docker compose build
+        run: |
+          docker build -t ghcr.io/${{ github.repository_owner }}/blauclan-backend:${{ steps.vars.outputs.BACKEND_VERSION }} \
+            -t ghcr.io/${{ github.repository_owner }}/blauclan-backend:latest ./backend
+          docker build -t ghcr.io/${{ github.repository_owner }}/blauclan-frontend:${{ steps.vars.outputs.FRONTEND_VERSION }} \
+            -t ghcr.io/${{ github.repository_owner }}/blauclan-frontend:latest ./frontend
+      - name: Push Docker images
+        if: github.event_name == 'push'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker push ghcr.io/${{ github.repository_owner }}/blauclan-backend:${{ steps.vars.outputs.BACKEND_VERSION }}
+          docker push ghcr.io/${{ github.repository_owner }}/blauclan-backend:latest
+          docker push ghcr.io/${{ github.repository_owner }}/blauclan-frontend:${{ steps.vars.outputs.FRONTEND_VERSION }}
+          docker push ghcr.io/${{ github.repository_owner }}/blauclan-frontend:latest

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ docker-compose up --build
 
 The API will be available on `http://localhost:3000` and the front-end on `http://localhost:8080`.
 
+### Running with Prebuilt Images
+
+After Docker images are published to GitHub Container Registry you can run the stack with:
+
+```bash
+docker-compose -f docker-compose.deploy.yml up -d
+```
+
+Replace `OWNER` in `docker-compose.deploy.yml` with your GitHub username or organisation.
+
 ### API Endpoints
 
 - `GET /api/people`

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  db:
+    image: postgres:13-alpine
+    environment:
+      POSTGRES_DB: familytree
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+  backend:
+    image: ghcr.io/OWNER/blauclan-backend:latest
+    environment:
+      DB_NAME: familytree
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_HOST: db
+    ports:
+      - '3000:3000'
+    depends_on:
+      - db
+  frontend:
+    image: ghcr.io/OWNER/blauclan-frontend:latest
+    ports:
+      - '8080:80'
+    depends_on:
+      - backend
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- update CI workflow to push Docker images to ghcr.io when pushing to main
- document how to run stack with prebuilt images
- add docker-compose file referencing images from the registry

## Testing
- `npm install` *(backend)*
- `npm test` *(fails: Missing script)*
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f28deb8083309203f32504e4e409