### PR TITLE
Fix backend port mapping via nginx proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+backend/node_modules/
+backend/package-lock.json
+frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The project is split into two folders:
 docker-compose up --build
 ```
 
-The API will be available on `http://localhost:3000` and the front-end on `http://localhost:8080`.
+The API will be available through the front-end container under `/api`. By default
+the backend container exposes port `3000`, but you can map this to any host port
+in `docker-compose.yml` (e.g. `3009:3000`). The front-end itself is served on
+`http://localhost:8080`.
 
 ### Running with Prebuilt Images
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:alpine
 COPY index.html /usr/share/nginx/html/index.html
+COPY default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/frontend/default.conf
+++ b/frontend/default.conf
@@ -1,0 +1,16 @@
+server {
+  listen 80;
+  server_name localhost;
+
+  location / {
+    root /usr/share/nginx/html;
+    index index.html;
+    try_files $uri $uri/ /index.html;
+  }
+
+  location /api/ {
+    proxy_pass http://backend:3000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+  }
+}


### PR DESCRIPTION
## Summary
- ignore node modules and lockfiles
- proxy API requests from Nginx frontend container to the backend
- document new behaviour with `/api` path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845f8bc0a748330b979a0d8fa99aa59