### PR TITLE
Add initial Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ docker-compose -f docker-compose.deploy.yml up -d
 
 Replace `OWNER` in `docker-compose.deploy.yml` with your GitHub username or organisation.
 
+### Running Backend Tests
+
+To execute the API test suite, run:
+
+```bash
+cd backend && npm test
+```
+
 ### API Endpoints
 
 - `GET /api/people`

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "dev": "nodemon src/index.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -14,6 +15,8 @@
     "sqlite3": "^5.1.6"
   },
   "devDependencies": {
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.22",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -45,8 +45,12 @@ app.get('/api/export/json', async (_req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-sequelize.sync().then(() => {
-  app.listen(PORT, () => {
-    console.log(`Server running on port ${PORT}`);
+if (require.main === module) {
+  sequelize.sync().then(() => {
+    app.listen(PORT, () => {
+      console.log(`Server running on port ${PORT}`);
+    });
   });
-});
+}
+
+module.exports = app;

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -1,0 +1,33 @@
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const request = require('supertest');
+const app = require('../src/index');
+const sequelize = require('../src/models');
+
+beforeAll(async () => {
+  await sequelize.sync({ force: true });
+});
+
+afterAll(async () => {
+  await sequelize.close();
+});
+
+describe('People API', () => {
+  test('GET /api/people returns empty array', async () => {
+    const res = await request(app).get('/api/people');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  test('POST /api/people creates a person', async () => {
+    const res = await request(app)
+      .post('/api/people')
+      .send({ firstName: 'John', lastName: 'Doe' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.firstName).toBe('John');
+
+    const list = await request(app).get('/api/people');
+    expect(list.body.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and Supertest with npm script
- export Express app for testing
- create simple API tests
- document how to run backend tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f8d34c348330a10969f6da28f209