### PR TITLE
Add configurable backend port

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ docker-compose up --build
 ```
 
 The API will be available through the front-end container under `/api`. By default
-the backend container exposes port `3000`, but you can map this to any host port
-in `docker-compose.yml` (e.g. `3009:3000`). The front-end itself is served on
+the backend listens on port `3009`. You can change this by setting the
+`BACKEND_PORT` environment variable when running `docker-compose`. The value is
+used for both the Node.js server and the Nginx proxy configuration. The front-end itself is served on
 `http://localhost:8080`.
 
 ### Running with Prebuilt Images

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install --production || true
 COPY src ./src
-EXPOSE 3000
+EXPOSE 3009
 CMD ["npm", "start"]

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -44,7 +44,7 @@ app.get('/api/export/json', async (_req, res) => {
   res.json(people);
 });
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3009;
 if (require.main === module) {
   sequelize.sync().then(() => {
     app.listen(PORT, () => {

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -15,12 +15,15 @@ services:
       DB_USER: postgres
       DB_PASSWORD: postgres
       DB_HOST: db
+      PORT: ${BACKEND_PORT:-3009}
     ports:
-      - '3000:3000'
+      - '${BACKEND_PORT:-3009}:${BACKEND_PORT:-3009}'
     depends_on:
       - db
   frontend:
     image: ghcr.io/OWNER/blauclan-frontend:latest
+    environment:
+      BACKEND_PORT: ${BACKEND_PORT:-3009}
     ports:
       - '8080:80'
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,15 @@ services:
       DB_USER: postgres
       DB_PASSWORD: postgres
       DB_HOST: db
+      PORT: ${BACKEND_PORT:-3009}
     ports:
-      - '3000:3000'
+      - '${BACKEND_PORT:-3009}:${BACKEND_PORT:-3009}'
     depends_on:
       - db
   frontend:
     build: ./frontend
+    environment:
+      BACKEND_PORT: ${BACKEND_PORT:-3009}
     ports:
       - '8080:80'
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,7 @@
 FROM nginx:alpine
 COPY index.html /usr/share/nginx/html/index.html
-COPY default.conf /etc/nginx/conf.d/default.conf
+COPY default.conf.template /etc/nginx/conf.d/default.conf.template
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 EXPOSE 80
+CMD ["/docker-entrypoint.sh"]

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -9,7 +9,7 @@ server {
   }
 
   location /api/ {
-    proxy_pass http://backend:3000/;
+    proxy_pass http://backend:${BACKEND_PORT}/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
   }

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+# Substitute BACKEND_PORT env var into nginx config
+envsubst '$BACKEND_PORT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- allow overriding backend port via `BACKEND_PORT` env variable
- update backend default port to 3009
- rewrite nginx config to use envsubst for the backend port
- document port configuration

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845fc48843c8330b3b7682436dbeca6