### PR TITLE
Improve frontend editing features

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -51,7 +51,9 @@
             lastName: '',
             fatherId: '',
             motherId: '',
+            notes: '',
           },
+          selectedPerson: null,
         };
       },
       async mounted() {
@@ -67,7 +69,7 @@
           if (!payload.motherId) delete payload.motherId; else payload.motherId = parseInt(payload.motherId);
           const person = await createPerson(payload);
           this.people.push(person);
-          this.newPerson = { firstName: '', lastName: '', fatherId: '', motherId: '' };
+          this.newPerson = { firstName: '', lastName: '', fatherId: '', motherId: '', notes: '' };
         },
         async updateParents(person) {
           const updates = {
@@ -76,6 +78,23 @@
           };
           const updated = await updatePerson(person.id, updates);
           Object.assign(person, updated);
+        },
+        selectPerson(person) {
+          this.selectedPerson = { ...person };
+        },
+        async savePerson() {
+          if (!this.selectedPerson) return;
+          const payload = {
+            firstName: this.selectedPerson.firstName,
+            lastName: this.selectedPerson.lastName,
+            fatherId: this.selectedPerson.fatherId || null,
+            motherId: this.selectedPerson.motherId || null,
+            notes: this.selectedPerson.notes || '',
+          };
+          const updated = await updatePerson(this.selectedPerson.id, payload);
+          const idx = this.people.findIndex((p) => p.id === updated.id);
+          if (idx !== -1) Object.assign(this.people[idx], updated);
+          this.selectedPerson = null;
         },
       },
     });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,38 @@
 <body>
   <div id="app">
     <h1>BlauClan</h1>
-    <button id="add-node">＋</button>
+    <div id="menu">
+      <h2>Add Person</h2>
+      <form id="addForm" @submit.prevent="addPerson">
+        <input v-model="newPerson.firstName" placeholder="First Name">
+        <input v-model="newPerson.lastName" placeholder="Last Name">
+        <select v-model="newPerson.fatherId">
+          <option value="">Father</option>
+          <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
+        </select>
+        <select v-model="newPerson.motherId">
+          <option value="">Mother</option>
+          <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
+        </select>
+        <textarea v-model="newPerson.notes" placeholder="Notes"></textarea>
+        <button type="submit">Add</button>
+      </form>
+      <div v-if="selectedPerson" class="edit-section">
+        <h2>Edit Person</h2>
+        <input v-model="selectedPerson.firstName" placeholder="First Name">
+        <input v-model="selectedPerson.lastName" placeholder="Last Name">
+        <select v-model="selectedPerson.fatherId">
+          <option value="">Father</option>
+          <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
+        </select>
+        <select v-model="selectedPerson.motherId">
+          <option value="">Mother</option>
+          <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
+        </select>
+        <textarea v-model="selectedPerson.notes" placeholder="Notes"></textarea>
+        <button @click="savePerson">Save</button>
+      </div>
+    </div>
     <svg id="graph" width="100%" height="600"></svg>
   </div>
   <script src="app.js"></script>

--- a/frontend/tree.js
+++ b/frontend/tree.js
@@ -61,18 +61,24 @@
             .on('drag', dragged)
             .on('end', dragended)
         )
-        .on('mousedown', startLink);
+        .on('mousedown', startLink)
+        .on('dblclick', (_, d) => app.selectPerson(d));
 
       nodeEnter
-        .append('circle')
-        .attr('r', 20)
-        .attr('fill', '#69b3a2');
+        .append('rect')
+        .attr('width', 100)
+        .attr('height', 40)
+        .attr('x', -50)
+        .attr('y', -20)
+        .attr('rx', 6)
+        .attr('fill', '#fff')
+        .attr('stroke', '#69b3a2');
 
       nodeEnter
         .append('text')
-        .attr('y', 4)
         .attr('text-anchor', 'middle')
-        .text((d) => d.firstName);
+        .attr('y', 5)
+        .text((d) => `${d.firstName} ${d.lastName}`);
 
       node.exit().remove();
 
@@ -170,18 +176,11 @@
       }
     }
 
-    document.getElementById('add-node').addEventListener('click', async () => {
-      const firstName = prompt('First name');
-      if (!firstName) return;
-      const lastName = prompt('Last name') || '';
-      try {
-        const person = await FrontendApp.createPerson({ firstName, lastName });
-        app.people.push(person);
-        update();
-      } catch (e) {
-        alert('Failed to create');
-      }
-    });
+    app.$watch(
+      () => app.people,
+      () => update(),
+      { deep: true }
+    );
 
     update();
 


### PR DESCRIPTION
## Summary
- restore a simple person management menu
- allow editing notes and parents
- display nodes as rectangular cards
- update graph when people list changes

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68460a120aac8330bfef0c5c4111c918