### PR TITLE
Implement fixed layout and node management

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,12 @@
   <title>BlauClan</title>
   <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
   <script src="https://d3js.org/d3.v7.min.js"></script>
+  <style>
+    #menu { width: 250px; float: left; }
+    .edit-section { border: 1px solid #69b3a2; padding: 10px; border-radius: 6px; margin-top: 10px; }
+    .card { border: 1px solid #ccc; padding: 8px; margin-top: 8px; border-radius: 6px; }
+    #graph { border: 1px solid #ccc; }
+  </style>
 </head>
 <body>
   <div id="app">
@@ -39,6 +45,14 @@
         </select>
         <textarea v-model="selectedPerson.notes" placeholder="Notes"></textarea>
         <button @click="savePerson">Save</button>
+        <button @click="deleteSelected">Delete</button>
+        <div class="card">
+          <h3>Add Relations</h3>
+          <button @click="prepareAddChild">New Child</button>
+          <button @click="prepareAddSpouse">New Spouse</button>
+          <button @click="prepareAddParent('father')">Add Father</button>
+          <button @click="prepareAddParent('mother')">Add Mother</button>
+        </div>
       </div>
     </div>
     <svg id="graph" width="100%" height="600"></svg>

--- a/frontend/test/app.test.js
+++ b/frontend/test/app.test.js
@@ -1,4 +1,4 @@
-const { fetchPeople, createPerson } = require('../app');
+const { fetchPeople, createPerson, deletePerson } = require('../app');
 
 describe('frontend helpers', () => {
   beforeEach(() => {
@@ -21,5 +21,11 @@ describe('frontend helpers', () => {
     expect(options.method).toBe('POST');
     expect(JSON.parse(options.body).firstName).toBe('Jane');
     expect(person.id).toBe(2);
+  });
+
+  test('deletePerson deletes data', async () => {
+    global.fetch.mockResolvedValue({ ok: true });
+    await deletePerson(3);
+    expect(global.fetch).toHaveBeenCalledWith('/api/people/3', { method: 'DELETE' });
   });
 });


### PR DESCRIPTION
## Summary
- stop force graph animation and compute layout once per update
- open node edit card on click with options to add relations
- allow deleting people from the front-end
- support creating spouses and parents on add-person flow
- add tests for new helper

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68460ca2a3c0833094b4815035998aa8