### PR TITLE
Implement spouse management in frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,9 @@
       <form id="addForm" @submit.prevent="addPerson">
         <input v-model="newPerson.firstName" placeholder="First Name">
         <input v-model="newPerson.lastName" placeholder="Last Name">
+        <input type="date" v-model="newPerson.dateOfBirth" placeholder="DoB">
+        <input type="date" v-model="newPerson.dateOfDeath" placeholder="DoD">
+        <input v-model="newPerson.placeOfBirth" placeholder="Place of Birth">
         <select v-model="newPerson.fatherId">
           <option value="">Father</option>
           <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
@@ -35,6 +38,9 @@
         <h2>Edit Person</h2>
         <input v-model="selectedPerson.firstName" placeholder="First Name">
         <input v-model="selectedPerson.lastName" placeholder="Last Name">
+        <input type="date" v-model="selectedPerson.dateOfBirth" placeholder="DoB">
+        <input type="date" v-model="selectedPerson.dateOfDeath" placeholder="DoD">
+        <input v-model="selectedPerson.placeOfBirth" placeholder="Place of Birth">
         <select v-model="selectedPerson.fatherId">
           <option value="">Father</option>
           <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
@@ -46,6 +52,28 @@
         <textarea v-model="selectedPerson.notes" placeholder="Notes"></textarea>
         <button @click="savePerson">Save</button>
         <button @click="deleteSelected">Delete</button>
+        <div v-if="spouses.length" class="card">
+          <h3>Spouses</h3>
+          <ul>
+            <li v-for="s in spouses">{{ s.spouse.firstName }} {{ s.spouse.lastName }}</li>
+          </ul>
+        </div>
+        <div v-if="showSpouseForm" class="card">
+          <h3>Add Spouse</h3>
+          <select v-model="spouseForm.existingId">
+            <option value="">-- New Person --</option>
+            <option v-for="p in people" :key="p.id" :value="p.id" v-if="p.id!==selectedPerson.id && !spouses.some(s=>s.spouse.id===p.id)">{{ p.firstName }} {{ p.lastName }}</option>
+          </select>
+          <div v-if="!spouseForm.existingId">
+            <input v-model="spouseForm.firstName" placeholder="First Name">
+            <input v-model="spouseForm.lastName" placeholder="Last Name">
+            <input type="date" v-model="spouseForm.dateOfBirth" placeholder="DoB">
+            <input type="date" v-model="spouseForm.dateOfDeath" placeholder="DoD">
+            <input v-model="spouseForm.placeOfBirth" placeholder="Place of Birth">
+          </div>
+          <button @click="confirmAddSpouse">Add</button>
+          <button @click="cancelAddSpouse">Cancel</button>
+        </div>
         <div class="card">
           <h3>Add Relations</h3>
           <button @click="prepareAddChild">New Child</button>

--- a/frontend/test/app.test.js
+++ b/frontend/test/app.test.js
@@ -1,4 +1,4 @@
-const { fetchPeople, createPerson, deletePerson } = require('../app');
+const { fetchPeople, createPerson, deletePerson, linkSpouse, fetchSpouses } = require('../app');
 
 describe('frontend helpers', () => {
   beforeEach(() => {
@@ -27,5 +27,18 @@ describe('frontend helpers', () => {
     global.fetch.mockResolvedValue({ ok: true });
     await deletePerson(3);
     expect(global.fetch).toHaveBeenCalledWith('/api/people/3', { method: 'DELETE' });
+  });
+
+  test('linkSpouse posts relationship', async () => {
+    global.fetch.mockResolvedValue({ ok: true, json: () => ({ id: 1 }) });
+    await linkSpouse(1, 2);
+    expect(global.fetch).toHaveBeenCalledWith('/api/people/1/spouses', expect.objectContaining({ method: 'POST' }));
+  });
+
+  test('fetchSpouses gets list', async () => {
+    global.fetch.mockResolvedValue({ ok: true, json: () => [{ spouse: { id: 2 } }] });
+    const data = await fetchSpouses(1);
+    expect(global.fetch).toHaveBeenCalledWith('/api/people/1/spouses');
+    expect(data[0].spouse.id).toBe(2);
   });
 });

--- a/frontend/tree.js
+++ b/frontend/tree.js
@@ -93,9 +93,9 @@
       nodeEnter
         .append('rect')
         .attr('width', 100)
-        .attr('height', 40)
+        .attr('height', 60)
         .attr('x', -50)
-        .attr('y', -20)
+        .attr('y', -30)
         .attr('rx', 6)
         .attr('fill', '#fff')
         .attr('stroke', '#69b3a2');
@@ -103,8 +103,20 @@
       nodeEnter
         .append('text')
         .attr('text-anchor', 'middle')
-        .attr('y', 5)
+        .attr('y', -10)
         .text((d) => `${d.firstName} ${d.lastName}`);
+
+      nodeEnter
+        .append('text')
+        .attr('text-anchor', 'middle')
+        .attr('y', 5)
+        .text((d) => (d.dateOfBirth ? `b. ${d.dateOfBirth}` : ''));
+
+      nodeEnter
+        .append('text')
+        .attr('text-anchor', 'middle')
+        .attr('y', 20)
+        .text((d) => (d.placeOfBirth ? d.placeOfBirth : ''));
 
       node.exit().remove();
       updatePositions();


### PR DESCRIPTION
## Summary
- enhance frontend helper methods to fetch spouse data
- extend app state with spouse info and forms
- allow linking existing people as spouses or creating new ones
- show additional fields (birth, death, place) when adding/editing
- display spouse list in the person card and show basic dates/places in nodes
- update unit tests for new helper functions

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68466b9306fc83309df5177986aa6876