### PR TITLE
Fix spouse option filter bug

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -199,6 +199,13 @@
         cancelAddSpouse() {
           this.showSpouseForm = false;
         },
+        isEligibleSpouse(person) {
+          if (!this.selectedPerson) return false;
+          return (
+            person.id !== this.selectedPerson.id &&
+            !this.spouses.some((s) => s.spouse.id === person.id)
+          );
+        },
         prepareAddParent(type) {
           if (!this.selectedPerson) return;
           this.newPerson = {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,7 +62,7 @@
           <h3>Add Spouse</h3>
           <select v-model="spouseForm.existingId">
             <option value="">-- New Person --</option>
-            <option v-for="p in people" :key="p.id" :value="p.id" v-if="p.id!==selectedPerson.id && !spouses.some(s=>s.spouse.id===p.id)">{{ p.firstName }} {{ p.lastName }}</option>
+            <option v-for="p in people" :key="p.id" :value="p.id" v-if="isEligibleSpouse(p)">{{ p.firstName }} {{ p.lastName }}</option>
           </select>
           <div v-if="!spouseForm.existingId">
             <input v-model="spouseForm.firstName" placeholder="First Name">


### PR DESCRIPTION
## Summary
- allow spouse option filter via `isEligibleSpouse` helper
- use the helper in the spouse select dropdown

## Testing
- `cd frontend && npm test --silent`
- `cd ../backend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68466ef88cd0833087348abf20fb2bf5