### PR TITLE
Fix runtime errors by defining Handle and jQuery

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -15,10 +15,10 @@
 
   function mount() {
     const { createApp, ref, reactive, onMounted, watch } = Vue;
-    const { VueFlow, MarkerType } = window.VueFlow;
+    const { VueFlow, MarkerType, Handle } = window.VueFlow;
 
     const app = createApp({
-      components: { VueFlow },
+      components: { VueFlow, Handle },
       setup() {
         const nodes = ref([]);
         const edges = ref([]);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,11 @@
   <meta charset="UTF-8">
   <title>BlauClan</title>
   <script src="vue.global.js"></script>
+  <script>var production = 'development';</script>
   <link rel="stylesheet" href="vue-flow-style.css">
   <script src="vue-flow-core.iife.js"></script>
   <script>window.VueFlow = window.VueFlowCore;</script>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <link rel="stylesheet" href="assets/css/argon-design-system.min.css">
   <style>
     #menu { width: 250px; float: left; }


### PR DESCRIPTION
## Summary
- register Handle component in VueFlow setup
- load jQuery and define `production` before using Vue Flow

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68467bae85c8833093572c3b6b40de0a