### PR TITLE
Add sample data seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ To execute the API test suite, run:
 cd backend && npm test
 ```
 
+### Loading Sample Data
+
+For quick testing of the frontend you can populate the database with a small set
+of example records:
+
+```bash
+cd backend && npm run seed
+```
+
+This will insert a couple of people and a marriage so that the UI has something
+to display.
+
 ### API Endpoints
 
 - `GET /api/people`

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "jest"
+    "test": "jest",
+    "seed": "node src/seed.js"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/backend/sample-data.json
+++ b/backend/sample-data.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 1,
+    "firstName": "John",
+    "lastName": "Doe",
+    "gender": "M"
+  },
+  {
+    "id": 2,
+    "firstName": "Jane",
+    "lastName": "Smith",
+    "gender": "F"
+  },
+  {
+    "id": 3,
+    "firstName": "Child",
+    "lastName": "Doe",
+    "fatherId": 1,
+    "motherId": 2,
+    "gender": "M"
+  }
+]

--- a/backend/src/seed.js
+++ b/backend/src/seed.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const { sequelize, Person, Marriage } = require('./models');
+
+async function loadData() {
+  const dataPath = path.join(__dirname, '../sample-data.json');
+  const people = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  await sequelize.sync({ force: true });
+  for (const p of people) {
+    await Person.create(p);
+  }
+  // simple marriage between John (1) and Jane (2)
+  await Marriage.create({ personId: 1, spouseId: 2, dateOfMarriage: '2000-01-01' });
+  await sequelize.close();
+}
+
+if (require.main === module) {
+  loadData().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = loadData;


### PR DESCRIPTION
## Summary
- add example records for local testing
- include script to populate database
- document how to load sample data

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68467f59b3148330a05ac4d6c1c63d16