### PR TITLE
Add toggled new person form with relation hints

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -73,6 +73,7 @@
       data() {
         return {
           people: [],
+          showAddForm: false,
           newPerson: {
             firstName: '',
             lastName: '',
@@ -99,6 +100,28 @@
       },
       async mounted() {
         this.people = await fetchPeople();
+      },
+      computed: {
+        relationDescription() {
+          const rel = this.newPerson.relation;
+          if (rel) {
+            if (rel.type === 'spouse') {
+              const sp = this.people.find((p) => p.id === rel.personId);
+              return sp ? `is spouse of ${sp.firstName} ${sp.lastName}` : '';
+            } else if (rel.type === 'father' || rel.type === 'mother') {
+              const child = this.people.find((p) => p.id === rel.childId);
+              const role = rel.type === 'father' ? 'father' : 'mother';
+              return child ? `is ${role} of ${child.firstName} ${child.lastName}` : '';
+            }
+          }
+          const father = this.parentName(this.newPerson.fatherId);
+          const mother = this.parentName(this.newPerson.motherId);
+          if (father || mother) {
+            if (father && mother) return `is child of ${father} and ${mother}`;
+            return `is child of ${father || mother}`;
+          }
+          return '';
+        },
       },
       methods: {
         parentName(id) {
@@ -131,6 +154,7 @@
             notes: '',
             relation: null,
           };
+          this.showAddForm = false;
         },
         async updateParents(person) {
           const updates = {
@@ -164,6 +188,7 @@
             notes: '',
             relation: null,
           };
+          this.showAddForm = true;
         },
         prepareAddSpouse() {
           if (!this.selectedPerson) return;
@@ -218,6 +243,35 @@
             motherId: '',
             notes: '',
             relation: { type, childId: this.selectedPerson.id },
+          };
+          this.showAddForm = true;
+        },
+        openAddForm() {
+          this.newPerson = {
+            firstName: '',
+            lastName: '',
+            dateOfBirth: '',
+            dateOfDeath: '',
+            placeOfBirth: '',
+            fatherId: '',
+            motherId: '',
+            notes: '',
+            relation: null,
+          };
+          this.showAddForm = true;
+        },
+        cancelAddPerson() {
+          this.showAddForm = false;
+          this.newPerson = {
+            firstName: '',
+            lastName: '',
+            dateOfBirth: '',
+            dateOfDeath: '',
+            placeOfBirth: '',
+            fatherId: '',
+            motherId: '',
+            notes: '',
+            relation: null,
           };
         },
         async savePerson() {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,7 +26,9 @@
     <h1>BlauClan</h1>
     <div id="menu">
       <h2>Add Person</h2>
-      <form id="addForm" @submit.prevent="addPerson" class="form-group">
+      <button class="btn btn-primary mb-2" @click="openAddForm" v-if="!showAddForm">Add New Person</button>
+      <form v-if="showAddForm" id="addForm" @submit.prevent="addPerson" class="form-group">
+        <p v-if="relationDescription" class="alert alert-info p-2">{{ relationDescription }}</p>
         <input class="form-control mb-2" v-model="newPerson.firstName" placeholder="First Name">
         <input class="form-control mb-2" v-model="newPerson.lastName" placeholder="Last Name">
         <input class="form-control mb-2" type="date" v-model="newPerson.dateOfBirth" placeholder="DoB">
@@ -41,7 +43,8 @@
           <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
         </select>
         <textarea class="form-control mb-2" v-model="newPerson.notes" placeholder="Notes"></textarea>
-        <button class="btn btn-primary" type="submit">Add</button>
+        <button class="btn btn-primary mr-2" type="submit">Add</button>
+        <button class="btn btn-secondary" type="button" @click="cancelAddPerson">Cancel</button>
       </form>
       <div v-if="selectedPerson" class="edit-section">
         <h2>Edit Person</h2>


### PR DESCRIPTION
## Summary
- hide add person form by default and show it when Add New Person is clicked
- show relation info (child/spouse/parent) in the new person form

## Testing
- `npm test --silent --prefix backend`
- `npm install --silent --prefix frontend`
- `npm test --silent --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_684682d95dfc8330b68c2cdb53cf3ccc