### PR TITLE
Fix flatpickr missing dependency

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,8 @@
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
   <link rel="stylesheet" href="assets/css/argon-design-system.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <style>
     #menu { width: 250px; float: left; }
     .edit-section { border: 1px solid #69b3a2; padding: 10px; border-radius: 6px; margin-top: 10px; }


### PR DESCRIPTION
## Summary
- include flatpickr CSS/JS CDN links in `index.html`

## Testing
- `cd backend && npm test`
- `cd frontend && npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68468c326c4c83308bff340782346472