### PR TITLE
Add labels and child management

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -122,6 +122,12 @@
           }
           return '';
         },
+        childrenOfSelected() {
+          if (!this.selectedPerson) return [];
+          return this.people.filter(
+            (c) => c.fatherId === this.selectedPerson.id || c.motherId === this.selectedPerson.id
+          );
+        },
       },
       methods: {
         parentName(id) {
@@ -230,6 +236,14 @@
             person.id !== this.selectedPerson.id &&
             !this.spouses.some((s) => s.spouse.id === person.id)
           );
+        },
+        async unlinkChild(child) {
+          const updates = {};
+          if (child.fatherId === this.selectedPerson.id) updates.fatherId = null;
+          if (child.motherId === this.selectedPerson.id) updates.motherId = null;
+          const updated = await updatePerson(child.id, updates);
+          const idx = this.people.findIndex((p) => p.id === updated.id);
+          if (idx !== -1) Object.assign(this.people[idx], updated);
         },
         prepareAddParent(type) {
           if (!this.selectedPerson) return;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,38 +38,54 @@
       <button class="btn btn-primary mb-2" @click="openAddForm" v-if="!showAddForm">Add New Person</button>
       <form v-if="showAddForm" id="addForm" @submit.prevent="addPerson" class="form-group">
         <p v-if="relationDescription" class="alert alert-info p-2">{{ relationDescription }}</p>
+        <label>First Name</label>
         <input class="form-control mb-2" v-model="newPerson.firstName" placeholder="First Name">
+        <label>Last Name</label>
         <input class="form-control mb-2" v-model="newPerson.lastName" placeholder="Last Name">
+        <label>Date of Birth</label>
         <input class="form-control mb-2" type="date" v-model="newPerson.dateOfBirth" placeholder="DoB">
+        <label>Date of Death</label>
         <input class="form-control mb-2" type="date" v-model="newPerson.dateOfDeath" placeholder="DoD">
+        <label>Place of Birth</label>
         <input class="form-control mb-2" v-model="newPerson.placeOfBirth" placeholder="Place of Birth">
+        <label>Father</label>
         <select class="form-control mb-2" v-model="newPerson.fatherId">
           <option value="">Father</option>
           <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
         </select>
+        <label>Mother</label>
         <select class="form-control mb-2" v-model="newPerson.motherId">
           <option value="">Mother</option>
           <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
         </select>
+        <label>Notes</label>
         <textarea class="form-control mb-2" v-model="newPerson.notes" placeholder="Notes"></textarea>
         <button class="btn btn-primary mr-2" type="submit">Add</button>
         <button class="btn btn-secondary" type="button" @click="cancelAddPerson">Cancel</button>
       </form>
       <div v-if="selectedPerson" class="edit-section">
         <h2>Edit Person</h2>
+        <label>First Name</label>
         <input class="form-control mb-2" v-model="selectedPerson.firstName" placeholder="First Name">
+        <label>Last Name</label>
         <input class="form-control mb-2" v-model="selectedPerson.lastName" placeholder="Last Name">
+        <label>Date of Birth</label>
         <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfBirth" placeholder="DoB">
+        <label>Date of Death</label>
         <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfDeath" placeholder="DoD">
+        <label>Place of Birth</label>
         <input class="form-control mb-2" v-model="selectedPerson.placeOfBirth" placeholder="Place of Birth">
+        <label>Father</label>
         <select class="form-control mb-2" v-model="selectedPerson.fatherId">
           <option value="">Father</option>
           <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
         </select>
+        <label>Mother</label>
         <select class="form-control mb-2" v-model="selectedPerson.motherId">
           <option value="">Mother</option>
           <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
         </select>
+        <label>Notes</label>
         <textarea class="form-control mb-2" v-model="selectedPerson.notes" placeholder="Notes"></textarea>
         <button class="btn btn-success mr-2" @click="savePerson">Save</button>
         <button class="btn btn-danger" @click="deleteSelected">Delete</button>
@@ -79,17 +95,32 @@
             <li v-for="s in spouses">{{ s.spouse.firstName }} {{ s.spouse.lastName }}</li>
           </ul>
         </div>
+        <div v-if="childrenOfSelected.length" class="card">
+          <h3>Children</h3>
+          <ul>
+            <li v-for="c in childrenOfSelected" :key="c.id">
+              {{ c.firstName }} {{ c.lastName }}
+              <button class="btn btn-sm btn-danger ml-1" @click="unlinkChild(c)">x</button>
+            </li>
+          </ul>
+        </div>
         <div v-if="showSpouseForm" class="card">
           <h3>Add Spouse</h3>
+          <label>Existing Person</label>
           <select class="form-control mb-2" v-model="spouseForm.existingId">
             <option value="">-- New Person --</option>
             <option v-for="p in people" :key="p.id" :value="p.id" v-if="isEligibleSpouse(p)">{{ p.firstName }} {{ p.lastName }}</option>
           </select>
           <div v-if="!spouseForm.existingId">
+            <label>First Name</label>
             <input class="form-control mb-2" v-model="spouseForm.firstName" placeholder="First Name">
+            <label>Last Name</label>
             <input class="form-control mb-2" v-model="spouseForm.lastName" placeholder="Last Name">
+            <label>Date of Birth</label>
             <input class="form-control mb-2" type="date" v-model="spouseForm.dateOfBirth" placeholder="DoB">
+            <label>Date of Death</label>
             <input class="form-control mb-2" type="date" v-model="spouseForm.dateOfDeath" placeholder="DoD">
+            <label>Place of Birth</label>
             <input class="form-control mb-2" v-model="spouseForm.placeOfBirth" placeholder="Place of Birth">
           </div>
           <button class="btn btn-primary mr-2" @click="confirmAddSpouse">Add</button>


### PR DESCRIPTION
## Summary
- add computed children list and unlinkChild method
- show labels for all input fields
- list children with delete link
- sync spouse link in flow modal

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6846a14da1cc83309f57ffc0b2470839