### PR TITLE
Add maiden name field to forms

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -77,6 +77,7 @@
           newPerson: {
             firstName: '',
             lastName: '',
+            maidenName: '',
             dateOfBirth: '',
             dateOfDeath: '',
             placeOfBirth: '',
@@ -92,6 +93,7 @@
             existingId: '',
             firstName: '',
             lastName: '',
+            maidenName: '',
             dateOfBirth: '',
             dateOfDeath: '',
             placeOfBirth: '',
@@ -149,9 +151,10 @@
             }
           }
           this.people.push(person);
-          this.newPerson = {
+         this.newPerson = {
             firstName: '',
             lastName: '',
+            maidenName: '',
             dateOfBirth: '',
             dateOfDeath: '',
             placeOfBirth: '',
@@ -183,9 +186,10 @@
         },
         prepareAddChild() {
           if (!this.selectedPerson) return;
-          this.newPerson = {
+         this.newPerson = {
             firstName: '',
             lastName: '',
+            maidenName: '',
             dateOfBirth: '',
             dateOfDeath: '',
             placeOfBirth: '',
@@ -196,13 +200,14 @@
           };
           this.showAddForm = true;
         },
-        prepareAddSpouse() {
+       prepareAddSpouse() {
           if (!this.selectedPerson) return;
           this.showSpouseForm = true;
           this.spouseForm = {
             existingId: '',
             firstName: '',
             lastName: '',
+            maidenName: '',
             dateOfBirth: '',
             dateOfDeath: '',
             placeOfBirth: '',
@@ -210,12 +215,13 @@
         },
         async confirmAddSpouse() {
           if (!this.selectedPerson) return;
-          if (this.spouseForm.existingId) {
+         if (this.spouseForm.existingId) {
             await linkSpouse(this.selectedPerson.id, parseInt(this.spouseForm.existingId));
           } else {
             const payload = {
               firstName: this.spouseForm.firstName,
               lastName: this.spouseForm.lastName,
+              maidenName: this.spouseForm.maidenName || undefined,
               dateOfBirth: this.spouseForm.dateOfBirth || undefined,
               dateOfDeath: this.spouseForm.dateOfDeath || undefined,
               placeOfBirth: this.spouseForm.placeOfBirth || undefined,
@@ -245,11 +251,12 @@
           const idx = this.people.findIndex((p) => p.id === updated.id);
           if (idx !== -1) Object.assign(this.people[idx], updated);
         },
-        prepareAddParent(type) {
+       prepareAddParent(type) {
           if (!this.selectedPerson) return;
           this.newPerson = {
             firstName: '',
             lastName: '',
+            maidenName: '',
             dateOfBirth: '',
             dateOfDeath: '',
             placeOfBirth: '',
@@ -260,10 +267,11 @@
           };
           this.showAddForm = true;
         },
-        openAddForm() {
+       openAddForm() {
           this.newPerson = {
             firstName: '',
             lastName: '',
+            maidenName: '',
             dateOfBirth: '',
             dateOfDeath: '',
             placeOfBirth: '',
@@ -274,11 +282,12 @@
           };
           this.showAddForm = true;
         },
-        cancelAddPerson() {
+       cancelAddPerson() {
           this.showAddForm = false;
           this.newPerson = {
             firstName: '',
             lastName: '',
+            maidenName: '',
             dateOfBirth: '',
             dateOfDeath: '',
             placeOfBirth: '',
@@ -288,11 +297,12 @@
             relation: null,
           };
         },
-        async savePerson() {
+       async savePerson() {
           if (!this.selectedPerson) return;
           const payload = {
             firstName: this.selectedPerson.firstName,
             lastName: this.selectedPerson.lastName,
+            maidenName: this.selectedPerson.maidenName || '',
             dateOfBirth: this.selectedPerson.dateOfBirth || null,
             dateOfDeath: this.selectedPerson.dateOfDeath || null,
             placeOfBirth: this.selectedPerson.placeOfBirth || '',

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -176,10 +176,11 @@
 
         const isNew = ref(false);
 
-        function addPerson() {
+       function addPerson() {
           selected.value = {
             firstName: '',
             lastName: '',
+            maidenName: '',
             dateOfBirth: '',
             dateOfDeath: '',
             placeOfBirth: '',
@@ -212,9 +213,10 @@
         }
 
         async function saveNewPerson() {
-          const payload = {
+         const payload = {
             firstName: selected.value.firstName,
             lastName: selected.value.lastName,
+            maidenName: selected.value.maidenName || undefined,
             dateOfBirth: selected.value.dateOfBirth || undefined,
             dateOfDeath: selected.value.dateOfDeath || undefined,
             placeOfBirth: selected.value.placeOfBirth || undefined,
@@ -302,6 +304,8 @@
                   <input class="form-control mb-2" v-model="selected.firstName" placeholder="First Name" />
                   <label>Last Name</label>
                   <input class="form-control mb-2" v-model="selected.lastName" placeholder="Last Name" />
+                  <label>Maiden Name</label>
+                  <input class="form-control mb-2" v-model="selected.maidenName" placeholder="Maiden Name" />
                   <label>Date of Birth</label>
                   <input class="form-control mb-2" v-model="selected.dateOfBirth" type="date" />
                   <label>Date of Death</label>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,6 +42,8 @@
         <input class="form-control mb-2" v-model="newPerson.firstName" placeholder="First Name">
         <label>Last Name</label>
         <input class="form-control mb-2" v-model="newPerson.lastName" placeholder="Last Name">
+        <label>Maiden Name</label>
+        <input class="form-control mb-2" v-model="newPerson.maidenName" placeholder="Maiden Name">
         <label>Date of Birth</label>
         <input class="form-control mb-2" type="date" v-model="newPerson.dateOfBirth" placeholder="DoB">
         <label>Date of Death</label>
@@ -69,6 +71,8 @@
         <input class="form-control mb-2" v-model="selectedPerson.firstName" placeholder="First Name">
         <label>Last Name</label>
         <input class="form-control mb-2" v-model="selectedPerson.lastName" placeholder="Last Name">
+        <label>Maiden Name</label>
+        <input class="form-control mb-2" v-model="selectedPerson.maidenName" placeholder="Maiden Name">
         <label>Date of Birth</label>
         <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfBirth" placeholder="DoB">
         <label>Date of Death</label>
@@ -116,6 +120,8 @@
             <input class="form-control mb-2" v-model="spouseForm.firstName" placeholder="First Name">
             <label>Last Name</label>
             <input class="form-control mb-2" v-model="spouseForm.lastName" placeholder="Last Name">
+            <label>Maiden Name</label>
+            <input class="form-control mb-2" v-model="spouseForm.maidenName" placeholder="Maiden Name">
             <label>Date of Birth</label>
             <input class="form-control mb-2" type="date" v-model="spouseForm.dateOfBirth" placeholder="DoB">
             <label>Date of Death</label>


### PR DESCRIPTION
## Summary
- add maiden name to frontend form data structures
- expose maiden name input fields for create/edit actions
- support maiden name in flow modal

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846a9b4bc348330af2639b8ba57d326