### PR TITLE
Filter parent dropdowns

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -128,6 +128,15 @@
             (c) => c.fatherId === this.selectedPerson.id || c.motherId === this.selectedPerson.id
           );
         },
+        availableParentOptions() {
+          if (!this.selectedPerson) return this.people;
+          const excludeIds = new Set([this.selectedPerson.id]);
+          this.spouses.forEach((s) => {
+            if (s.spouse) excludeIds.add(s.spouse.id);
+          });
+          this.childrenOfSelected.forEach((c) => excludeIds.add(c.id));
+          return this.people.filter((p) => !excludeIds.has(p.id));
+        },
       },
       methods: {
         parentName(id) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -78,12 +78,12 @@
         <label>Father</label>
         <select class="form-control mb-2" v-model="selectedPerson.fatherId">
           <option value="">Father</option>
-          <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
+          <option v-for="p in availableParentOptions" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
         </select>
         <label>Mother</label>
         <select class="form-control mb-2" v-model="selectedPerson.motherId">
           <option value="">Mother</option>
-          <option v-for="p in people" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
+          <option v-for="p in availableParentOptions" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
         </select>
         <label>Notes</label>
         <textarea class="form-control mb-2" v-model="selectedPerson.notes" placeholder="Notes"></textarea>


### PR DESCRIPTION
## Summary
- filter father/mother options against children and spouses

## Testing
- `npm --prefix frontend test`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846aacdb57c8330a11b1f37065e9458