### PR TITLE
Improve person detail view

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,6 +28,20 @@
       min-width: 350px;
       max-width: 500px;
     }
+    .avatar-placeholder {
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      background: #ddd;
+      display: inline-block;
+    }
+    .person-node .avatar {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: #ddd;
+      margin-bottom: 4px;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- toggle edit mode in modal
- hide empty person fields and show avatar placeholder
- style avatar in index.html
- expose editing state to the template so Edit button works immediately

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846dbb96cd88330aebd59f179a38601