### PR TITLE
Improve bloodline highlighting

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,6 +25,8 @@
       stroke: #f00;
       stroke-width: 2px;
     }
+    .dim-node { opacity: 0.3; }
+    .dim-edge .vue-flow__edge-path { opacity: 0.3; }
     .modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center; }
     .modal-content {
       background: #fff;


### PR DESCRIPTION
## Summary
- update highlight logic to show only direct bloodline
- fade out unrelated nodes and edges
- adjust node templates and CSS for dimmed elements

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847542e15648330911c8f4998abd8af