### PR TITLE
Fix mobile canvas height

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -615,7 +615,7 @@
             <button @click="loadLayout" class="ml-2">Reload Layout</button>
           </div>
           <VueFlow
-            style="width: 100%; height: 600px"
+            style="width: 100%; height: 100%"
             v-model:nodes="nodes"
             v-model:edges="edges"
             @node-click="onNodeClick"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BlauClan</title>
   <script src="vue.global.js"></script>
   <script>var production = 'development';</script>
@@ -18,6 +19,12 @@
     .edit-section { border: 1px solid #69b3a2; padding: 10px; border-radius: 6px; margin-top: 10px; }
     .card { border: 1px solid #ccc; padding: 8px; margin-top: 8px; border-radius: 6px; }
     #flow-app { border: 1px solid #ccc; float: left; width: calc(100% - 260px); }
+    @media (max-width: 768px) {
+      #flow-app {
+        width: 100%;
+        height: 100vh;
+      }
+    }
     .person-node { background: #fff; border: 2px solid #ccc; padding: 6px; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
     .helper-node { width: 0; height: 0; }
     .highlight-node { border-color: #f00 !important; }
@@ -160,7 +167,7 @@
         </div>
       </div>
     </div>
-    <div id="flow-app" style="width:100%; height:600px;"></div>
+    <div id="flow-app" style="width:100%; height:100vh;"></div>
   </div>
   <script src="assets/js/argon-design-system.min.js"></script>
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- ensure the canvas stretches to the viewport on small screens
- let VueFlow use its container's height
- add missing viewport meta tag

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847548226148330b262dcca2703d846