### PR TITLE
Improve bloodline highlight

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,12 @@
       stroke: #f00;
       stroke-width: 2px;
     }
+    .faded-node {
+      opacity: 0.3;
+    }
+    .faded-edge .vue-flow__edge-path {
+      opacity: 0.3;
+    }
     .modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center; }
     .modal-content {
       background: #fff;


### PR DESCRIPTION
## Summary
- restrict highlight to direct ancestors and descendants
- fade unhighlighted nodes and edges for clarity

## Testing
- `cd frontend && npm run lint && npm test`
- `cd backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847c11d903483309ce9c6ccc0112e33