### PR TITLE
Fix Vue ref warning

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -193,6 +193,13 @@
             }
           });
 
+          // remove Vue internal refs that cause warnings when passed as props
+          edges.value = edges.value.map((edge) => {
+            const { ref: _unused, ...rest } = edge;
+            void _unused; // avoid eslint no-unused-vars warning
+            return rest;
+          });
+
           await applySavedLayout();
           refreshUnions();
         }


### PR DESCRIPTION
## Summary
- sanitize edges in `flow.js` to drop internal Vue refs before passing to components

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847e0b2ffc48330ac99fb4009822107