### PR TITLE
Enable canvas click to clear selection

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -319,6 +319,13 @@
           }
         }
 
+        function onPaneClick() {
+          selected.value = null;
+          showModal.value = false;
+          editing.value = false;
+          clearHighlights();
+        }
+
         const saveSelected = debounce(async () => {
           if (!selected.value) return;
           const payload = { ...selected.value };
@@ -649,8 +656,9 @@
         return {
           nodes,
           edges,
-          onNodeClick,
-          onConnect,
+         onNodeClick,
+         onPaneClick,
+         onConnect,
           addPerson,
           deleteSelected,
           saveNewPerson,
@@ -684,6 +692,7 @@
             v-model:nodes="nodes"
             v-model:edges="edges"
             @node-click="onNodeClick"
+            @pane-click="onPaneClick"
             @connect="onConnect"
             @node-drag-stop="onNodeDragStop"
             :fit-view="true"


### PR DESCRIPTION
## Summary
- unhighlight nodes when clicking blank canvas
- wire up pane-click event on VueFlow

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847e7cd7f908330841a5bca8b0a624f