### PR TITLE
Fix curved edges for children with two parents

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -171,7 +171,7 @@
                   id: `${m.id}-${cid}`,
                   source: m.id,
                   target: String(cid),
-                  type: 'smoothstep',
+                  type: 'default',
                   markerEnd: MarkerType.ArrowClosed,
                   sourceHandle: handles.sourceHandle,
                   targetHandle: handles.targetHandle,


### PR DESCRIPTION
## Summary
- ensure child edges from spouse unions use the default curved style

## Testing
- `cd frontend && npm run lint`
- `npm test`
- `cd ../backend && npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847e8c6bcc08330970e96add4c3aabe