### PR TITLE
Add toolbar icon buttons

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -22,6 +22,7 @@
       setup() {
         const nodes = ref([]);
         const edges = ref([]);
+        const { fitView } = VueFlow.useZoomPanHelper();
         const selected = ref(null);
         const showModal = ref(false);
         let unions = {};
@@ -674,18 +675,30 @@
          editing,
          avatarSrc,
          optimizeLayout,
-         saveLayout,
+        saveLayout,
          loadLayout,
-          onNodeDragStop,
+         fitView,
+         onNodeDragStop,
         };
       },
       template: `
         <div style="width: 100%; height: 100%">
           <div id="toolbar">
-            <button @click="addPerson">+ Add Person</button>
-            <button @click="optimizeLayout" class="ml-2">Optimize Layout</button>
-            <button @click="saveLayout" class="ml-2">Save Layout</button>
-            <button @click="loadLayout" class="ml-2">Reload Layout</button>
+            <button class="icon-button" @click="addPerson" title="Add Person">
+              <svg viewBox="0 0 24 24"><path d="M5.25 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM2.25 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM18.75 7.5a.75.75 0 0 0-1.5 0v2.25H15a.75.75 0 0 0 0 1.5h2.25v2.25a.75.75 0 0 0 1.5 0v-2.25H21a.75.75 0 0 0 0-1.5h-2.25V7.5Z"/></svg>
+            </button>
+            <button class="icon-button" @click="optimizeLayout" title="Optimize Layout">
+              <svg viewBox="0 0 24 24"><path fill-rule="evenodd" d="M3 6a3 3 0 0 1 3-3h2.25a3 3 0 0 1 3 3v2.25a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V6Zm9.75 0a3 3 0 0 1 3-3H18a3 3 0 0 1 3 3v2.25a3 3 0 0 1-3 3h-2.25a3 3 0 0 1-3-3V6ZM3 15.75a3 3 0 0 1 3-3h2.25a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-2.25Zm9.75 0a3 3 0 0 1 3-3H18a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3h-2.25a3 3 0 0 1-3-3v-2.25Z" clip-rule="evenodd"/></svg>
+            </button>
+            <button class="icon-button" @click="saveLayout" title="Save Layout">
+              <svg viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2.25a.75.75 0 0 1 .75.75v11.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 1 1 1.06-1.06l3.22 3.22V3a.75.75 0 0 1 .75-.75Zm-9 13.5a.75.75 0 0 1 .75.75v2.25a1.5 1.5 0 0 0 1.5 1.5h13.5a1.5 1.5 0 0 0 1.5-1.5V16.5a.75.75 0 0 1 1.5 0v2.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V16.5a.75.75 0 0 1 .75-.75Z" clip-rule="evenodd"/></svg>
+            </button>
+            <button class="icon-button" @click="loadLayout" title="Reload Layout">
+              <svg viewBox="0 0 24 24"><path fill-rule="evenodd" d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z" clip-rule="evenodd"/></svg>
+            </button>
+            <button class="icon-button" @click="fitView" title="Fit to Screen">
+              <svg viewBox="0 0 24 24"><path fill-rule="evenodd" d="M15 3.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0V5.56l-3.97 3.97a.75.75 0 1 1-1.06-1.06l3.97-3.97h-2.69a.75.75 0 0 1-.75-.75Zm-12 0A.75.75 0 0 1 3.75 3h4.5a.75.75 0 0 1 0 1.5H5.56l3.97 3.97a.75.75 0 0 1-1.06 1.06L4.5 5.56v2.69a.75.75 0 0 1-1.5 0v-4.5Zm11.47 11.78a.75.75 0 1 1 1.06-1.06l3.97 3.97v-2.69a.75.75 0 0 1 1.5 0v4.5a.75.75 0 0 1-.75.75h-4.5a.75.75 0 0 1 0-1.5h2.69l-3.97-3.97Zm-4.94-1.06a.75.75 0 0 1 0 1.06L5.56 19.5h2.69a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75v-4.5a.75.75 0 0 1 1.5 0v2.69l3.97-3.97a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd"/></svg>
+            </button>
           </div>
           <VueFlow
             style="width: 100%; height: 100%"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -119,6 +119,35 @@
       object-fit: cover;
       margin-bottom: 4px;
     }
+    #toolbar {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+    .icon-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 36px;
+      background-color: #00B8D9;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
+      border: none;
+      padding: 0;
+    }
+    .icon-button:hover {
+      background-color: #00A1BD;
+    }
+    .icon-button:active {
+      background-color: #008EA8;
+    }
+    .icon-button svg {
+      width: 16px;
+      height: 16px;
+      fill: #ffffff;
+    }
   </style>
 </head>
 <body class="bright-theme">


### PR DESCRIPTION
## Summary
- add icon-only buttons with teal styling
- include `fitView` support and new Fit button

## Testing
- `npm --prefix backend run lint`
- `npm --prefix backend test`
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6847e9dc9c108330aeada777179d9e6a