### PR TITLE
Add header and footer layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,11 @@
   <link rel="stylesheet" href="assets/vendor/flatpickr.min.css">
   <script src="assets/vendor/flatpickr.min.js"></script>
   <style>
+    html, body { height: 100%; }
+    #page-wrapper { display: flex; flex-direction: column; min-height: 100vh; }
+    #main-content { flex: 1; }
+    #top-bar { background-color: #5e72e4; color: #fff; }
+    #footer { background-color: #f8f9fe; }
     #menu { width: 250px; float: left; }
     .edit-section { border: 1px solid #69b3a2; padding: 10px; border-radius: 6px; margin-top: 10px; }
     .card { border: 1px solid #ccc; padding: 8px; margin-top: 8px; border-radius: 6px; }
@@ -24,6 +29,7 @@
       float: left;
       width: calc(100% - 260px);
       touch-action: none;
+      height: calc(100vh - 90px);
     }
     body.dark-theme #flow-app {
       background-color: #1e1e1e;
@@ -38,7 +44,7 @@
     @media (max-width: 768px) {
       #flow-app {
         width: 100%;
-        height: 100vh;
+        height: calc(100vh - 90px);
         float: none;
         overflow: hidden;
       }
@@ -151,13 +157,19 @@
   </style>
 </head>
 <body class="bright-theme">
-  <div id="app">
-    <h1>BlauClan</h1>
-    <label class="custom-control custom-switch ml-2">
-      <input type="checkbox" class="custom-control-input" id="themeToggle">
-      <span class="custom-control-label">Dark Mode</span>
-    </label>
-    <div id="menu">
+  <div id="page-wrapper">
+    <header id="top-bar" class="py-2 px-3">
+      <div class="d-flex justify-content-between align-items-center">
+        <h1 class="h4 mb-0">BlauClan</h1>
+        <label class="custom-control custom-switch mb-0">
+          <input type="checkbox" class="custom-control-input" id="themeToggle">
+          <span class="custom-control-label">Dark Mode</span>
+        </label>
+      </div>
+    </header>
+    <div id="main-content">
+      <div id="app">
+        <div id="menu">
       <div v-if="selectedPerson" class="edit-section">
         <h2>Edit Person</h2>
         <div class="form-row">
@@ -218,7 +230,10 @@
         </div>
       </div>
     </div>
-    <div id="flow-app" style="width:100%; height:100vh; touch-action: none; overflow: hidden;"></div>
+        <div id="flow-app" style="touch-action: none; overflow: hidden;"></div>
+      </div>
+    </div>
+    <footer id="footer" class="text-center py-2">BlauClan &copy; 2023</footer>
   </div>
   <script src="assets/js/argon-design-system.min.js"></script>
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- reduce canvas height so header and footer fit in view
- add top bar with theme toggle and new footer

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847fc62ec0483308d4b613df01ca583