### PR TITLE
Improve card layout

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -692,10 +692,14 @@
           >
             <template #node-person="{ data }">
               <div class="person-node" :class="{ 'highlight-node': data.highlight, 'faded-node': selected && !data.highlight }" :style="{ borderColor: data.gender === 'female' ? '#f8c' : (data.gender === 'male' ? '#88f' : '#ccc') }">
-                <img :src="avatarSrc(data.gender, 40)" class="avatar" />
-                <div><strong>{{ data.firstName }} {{ data.lastName }}</strong></div>
-                <div>{{ data.dateOfBirth }} - {{ data.dateOfDeath }}</div>
-                <button class="add-child" @click.stop="addPerson">+</button>
+                <div class="header">
+                  <img :src="avatarSrc(data.gender, 40)" class="avatar" />
+                  <div class="name-container">
+                    <span :style="{ fontSize: data.firstName && data.firstName.length > 12 ? '0.7rem' : '0.8rem', fontWeight: 'bold' }">{{ data.firstName }}</span>
+                    <span :style="{ fontSize: data.lastName && data.lastName.length > 12 ? '0.7rem' : '0.8rem', fontWeight: 'bold' }">{{ data.lastName }}</span>
+                  </div>
+                </div>
+                <div class="small">{{ data.dateOfBirth }}<span v-if="data.dateOfBirth || data.dateOfDeath"> - </span>{{ data.dateOfDeath }}</div>
                 <Handle type="source" position="top" id="s-top" />
                 <Handle type="source" position="right" id="s-right" />
                 <Handle type="source" position="bottom" id="s-bottom" />
@@ -725,10 +729,13 @@
             >
               <div class="card-body p-3">
                 <template v-if="!editing && !isNew">
-                  <div class="text-center mb-2">
-                    <img :src="avatarSrc(selected.gender, 80)" class="avatar-placeholder" />
+                  <div class="d-flex align-items-center mb-3">
+                    <img :src="avatarSrc(selected.gender, 80)" class="avatar-placeholder mr-3" />
+                    <div class="name-container">
+                      <div class="h4 mb-0" :style="{ fontSize: selected.firstName && selected.firstName.length > 15 ? '1rem' : '1.25rem' }">{{ selected.firstName }}</div>
+                      <div class="h4 mb-0" :style="{ fontSize: selected.lastName && selected.lastName.length > 15 ? '1rem' : '1.25rem' }">{{ selected.lastName }}</div>
+                    </div>
                   </div>
-                  <h3 class="card-title text-center">{{ selected.firstName }} {{ selected.lastName }}</h3>
                   <p v-if="selected.maidenName"><strong>Maiden Name:</strong> {{ selected.maidenName }}</p>
                   <p v-if="selected.dateOfBirth || selected.dateOfDeath">
                     <strong>Life:</strong>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,6 +55,8 @@
       border-radius: 8px;
       box-shadow: 0 1px 3px rgba(0,0,0,0.4);
       transition: border-color 0.2s;
+      display: flex;
+      flex-direction: column;
     }
     body.dark-theme .person-node {
       background: #333;
@@ -119,12 +121,21 @@
       object-fit: cover;
       display: inline-block;
     }
+    .person-node .header {
+      display: flex;
+      align-items: flex-start;
+    }
+    .name-container {
+      display: flex;
+      flex-direction: column;
+      line-height: 1.1;
+    }
     .person-node .avatar {
       width: 40px;
       height: 40px;
       border-radius: 50%;
       object-fit: cover;
-      margin-bottom: 4px;
+      margin-right: 4px;
     }
     #toolbar {
       display: flex;


### PR DESCRIPTION
## Summary
- arrange person card layout with avatar left and names stacked
- show the same layout in the person details modal
- remove the add-child button from nodes

## Testing
- `cd frontend && npm run lint && npm test`
- `cd backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68480e15d02c8330a265c3e4861324ab