### PR TITLE
Handle empty parent IDs

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,9 +10,18 @@ app.get('/api/people', async (_req, res) => {
   res.json(people);
 });
 
+function normalizeParentIds(data) {
+  const updates = { ...data };
+  ['fatherId', 'motherId'].forEach((field) => {
+    if (updates[field] === '') updates[field] = null;
+  });
+  return updates;
+}
+
 app.post('/api/people', async (req, res) => {
   try {
-    const person = await Person.create(req.body);
+    const payload = normalizeParentIds(req.body);
+    const person = await Person.create(payload);
     res.status(201).json(person);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -32,7 +41,8 @@ app.put('/api/people/:id', async (req, res) => {
   if (Number.isNaN(id)) return res.status(400).json({ error: 'Invalid ID' });
   const person = await Person.findByPk(id);
   if (!person) return res.sendStatus(404);
-  await person.update(req.body);
+  const updates = normalizeParentIds(req.body);
+  await person.update(updates);
   res.json(person);
 });
 

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -41,4 +41,21 @@ describe('People API', () => {
     expect(getRes.statusCode).toBe(200);
     expect(getRes.body.nodes[0].x).toBe(100);
   });
+
+  test('handles empty parent IDs as null', async () => {
+    await request(app).post('/api/people').send({
+      firstName: 'Parent',
+      lastName: 'One',
+    });
+    const createRes = await request(app)
+      .post('/api/people')
+      .send({ firstName: 'Child', lastName: 'One', fatherId: 1 });
+    expect(createRes.statusCode).toBe(201);
+
+    const updateRes = await request(app)
+      .put(`/api/people/${createRes.body.id}`)
+      .send({ fatherId: '' });
+    expect(updateRes.statusCode).toBe(200);
+    expect(updateRes.body.fatherId).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- avoid invalid integer errors when unselecting parents
- test handling empty parent IDs

## Testing
- `npm --prefix backend run lint`
- `npm --prefix backend test`
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68480eb126088330b6e067d16644c2c3