### PR TITLE
Auto-fit tree on load

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -199,7 +199,10 @@
             .map((n) => n.data);
         }
 
-        onMounted(load);
+        onMounted(async () => {
+          await load();
+          fitView();
+        });
         const editing = ref(false);
 
         let clickTimer = null;
@@ -688,7 +691,7 @@
             @pane-click="onPaneClick"
             @connect="onConnect"
             @node-drag-stop="onNodeDragStop"
-            :fit-view="true"
+            :fit-view-on-init="true"
           >
             <template #node-person="{ data }">
               <div class="person-node" :class="{ 'highlight-node': data.highlight, 'faded-node': selected && !data.highlight }" :style="{ borderColor: data.gender === 'female' ? '#f8c' : (data.gender === 'male' ? '#88f' : '#ccc') }">


### PR DESCRIPTION
## Summary
- trigger `fitView()` when the flow component mounts so the family tree fits the screen initially
- use VueFlow `fit-view-on-init` prop

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68480ee02e548330abb71fd7b179d58b