### PR TITLE
Fix dark mode toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -187,7 +187,7 @@
         <h1 class="h4 mb-0">BlauClan</h1>
         <div id="themeToggleContainer" class="custom-control custom-switch mb-0">
           <input type="checkbox" class="custom-control-input" id="themeToggle">
-          <span id="themeIcon" class="custom-control-label">&#9728;</span>
+          <label id="themeIcon" for="themeToggle" class="custom-control-label">&#9728;</label>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- make theme toggle clickable again by associating the label with the checkbox

## Testing
- `cd frontend && npm run lint && npm test`
- `cd backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848151335148330af2dfd6579c8c322