### PR TITLE
Add canvas context menu

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -178,6 +178,31 @@
       top: 0.25rem;
       right: 0.5rem;
     }
+    .context-menu {
+      position: absolute;
+      background: #fff;
+      border: 1px solid #ccc;
+      list-style: none;
+      padding: 4px 0;
+      margin: 0;
+      z-index: 100;
+      min-width: 120px;
+    }
+    .context-menu li {
+      padding: 4px 12px;
+      cursor: pointer;
+    }
+    .context-menu li:hover {
+      background: #eee;
+    }
+    body.dark-theme .context-menu {
+      background: #333;
+      color: #eee;
+      border-color: #555;
+    }
+    body.dark-theme .context-menu li:hover {
+      background: #444;
+    }
   </style>
 </head>
 <body class="bright-theme">


### PR DESCRIPTION
## Summary
- add context menu styles
- implement context menu in `flow.js`
- show menu on right click or long tap
- allow add new person, clean up layout, and zoom to fit

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848162f67b88330a152d397583108ed