### PR TITLE
Update header/footer styles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,13 +15,15 @@
   <script src="assets/vendor/perfect-scrollbar.jquery.js"></script>
   <link rel="stylesheet" href="assets/css/argon-design-system.min.css">
   <link rel="stylesheet" href="assets/vendor/flatpickr.min.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&display=swap">
   <script src="assets/vendor/flatpickr.min.js"></script>
   <style>
     html, body { height: 100%; }
     #page-wrapper { display: flex; flex-direction: column; min-height: 100vh; }
     #main-content { flex: 1; }
     #top-bar { background-color: #5e72e4; color: #fff; }
-    #footer { background-color: #f8f9fe; }
+    #footer { background-color: #5e72e4; color: #fff; }
+    .brand-title { font-family: "Montserrat", sans-serif; font-weight: 700; }
     #menu { width: 250px; float: left; }
     .edit-section { border: 1px solid #69b3a2; padding: 10px; border-radius: 6px; margin-top: 10px; }
     .card { border: 1px solid #ccc; padding: 8px; margin-top: 8px; border-radius: 6px; }
@@ -217,7 +219,7 @@
   <div id="page-wrapper">
     <header id="top-bar" class="py-2 px-3">
       <div class="d-flex justify-content-between align-items-center">
-        <h1 class="h4 mb-0">Tree of Life</h1>
+        <h1 class="h4 mb-0 brand-title">Tree of Life</h1>
         <div id="themeToggleContainer" class="custom-control custom-switch mb-0">
           <input type="checkbox" class="custom-control-input" id="themeToggle">
           <label id="themeIcon" for="themeToggle" class="custom-control-label">&#9728;</label>


### PR DESCRIPTION
## Summary
- style header & footer with accent colour and white font
- use Montserrat bold font for the brand name in header

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68486ab214908330b9481e09c14c569f