### PR TITLE
Fix autosave overwriting issue

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -416,19 +416,19 @@
           addClass(evt.edge, 'selected-edge');
         }
 
-        const saveSelected = debounce(async () => {
-          if (!selected.value) return;
-          const payload = { ...selected.value };
-          const spouseId = payload.spouseId;
-          delete payload.spouseId;
-          const updated = await FrontendApp.updatePerson(selected.value.id, payload);
-          Object.assign(selected.value, updated);
-          if (spouseId) {
-            await FrontendApp.linkSpouse(updated.id, parseInt(spouseId));
-          }
-          await load();
-          computeChildren(updated.id);
-        }, 200);
+          const saveSelected = debounce(async () => {
+            if (!selected.value) return;
+            const payload = { ...selected.value };
+            const spouseId = payload.spouseId;
+            delete payload.spouseId;
+            const updated = await FrontendApp.updatePerson(selected.value.id, payload);
+            // Avoid overwriting fields the user may still be typing
+            if (spouseId) {
+              await FrontendApp.linkSpouse(updated.id, parseInt(spouseId));
+            }
+            await load();
+            computeChildren(updated.id);
+          }, 200);
 
         watch(
           () => selected.value,


### PR DESCRIPTION
## Summary
- avoid replacing the edited person with server data while autosaving

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68487e7614b883308127e4e735bc1136