### PR TITLE
Fix optimizeLayout Y positioning

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -726,6 +726,7 @@
         const levelGap = 150;
         const minGap = 120;
         const startX = 100;
+        const startY = 100;
 
         function parentX(node) {
           let sum = 0;
@@ -797,7 +798,7 @@
         });
 
         gens.forEach((g) => {
-          const y = startX + g * levelGap;
+          const y = startY + g * levelGap;
           byGen[g].forEach((n) => {
             n.position.y = y + (n.type === 'helper' ? UNION_Y_OFFSET : 0);
           });


### PR DESCRIPTION
## Summary
- define separate `startY` constant for vertical layout
- compute node Y positions from `startY` instead of `startX`

## Testing
- `npm run lint` & `npm test` in `frontend`
- `npm run lint` & `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6849cf1031b48330a6072743ae51212b