### PR TITLE
Implement tidy-up layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
   <script>var production = 'development';</script>
   <link rel="stylesheet" href="vue-flow-style.css">
   <script src="vue-flow-core.iife.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
   <script>window.VueFlow = window.VueFlowCore;</script>
   <script src="assets/vendor/jquery.min.js"></script>
   <script src="assets/vendor/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- add D3 script for layout calculations
- implement tidyUp using d3.tree
- trigger layout optimization via keyboard shortcut

## Testing
- `cd frontend && npm run lint && npm test`
- `cd backend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d13c21dc83308f758a70323eb985