### PR TITLE
Enable shift-drag multi-select

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -956,6 +956,9 @@
             @touchcancel="handleTouchEnd"
             :fit-view-on-init="true"
             :min-zoom="0.1"
+            :select-nodes-on-drag="true"
+            selection-key-code="Shift"
+            multi-selection-key-code="Shift"
           >
             <template #node-person="{ data }">
               <div class="person-node" :class="{ 'highlight-node': data.highlight, 'faded-node': selected && !data.highlight }" :style="{ borderColor: data.gender === 'female' ? '#f8c' : (data.gender === 'male' ? '#88f' : '#ccc') }">


### PR DESCRIPTION
## Summary
- activate node selection via shift-drag rectangle in Flow canvas

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849d6b6f6fc8330912f77e673dc40d5