### PR TITLE
Add SVG export feature

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -13,6 +13,7 @@
   "globals": {
     "Vue": "readonly",
     "FrontendApp": "readonly",
-    "VueFlow": "readonly"
+    "VueFlow": "readonly",
+    "ExportSvg": "readonly"
   }
 }

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -527,6 +527,32 @@
           if (toolbar) toolbar.style.display = originalDisplay;
         }
 
+        function buildHierarchy() {
+          const map = {};
+          nodes.value.forEach((n) => {
+            if (!n.data || n.data.helper) return;
+            map[n.data.id] = { ...n.data, children: [] };
+          });
+          Object.values(map).forEach((p) => {
+            const parent = map[p.fatherId] || map[p.motherId];
+            if (parent) parent.children.push(p);
+          });
+          return {
+            children: Object.values(map).filter(
+              (p) => !map[p.fatherId] && !map[p.motherId]
+            ),
+          };
+        }
+
+        function downloadSvg() {
+          const treeData = buildHierarchy();
+          ExportSvg.exportFamilyTree({
+            data: treeData,
+            svgEl: null,
+            colors: { male: '#4e79a7', female: '#f28e2b', '?': '#bab0ab' },
+          });
+        }
+
         async function onConnect(params) {
           const sH = params.sourceHandle || '';
           const tH = params.targetHandle || '';
@@ -904,6 +930,7 @@
         loadLayout,
         fitView,
         downloadPng,
+        downloadSvg,
         onNodeDragStop,
         handleContextMenu,
         handleTouchStart,
@@ -938,6 +965,12 @@
               <svg viewBox="0 0 24 24">
                 <path d="M12 9a3.75 3.75 0 1 0 0 7.5A3.75 3.75 0 0 0 12 9Z"/>
                 <path fill-rule="evenodd" d="M9.344 3.071a49.52 49.52 0 0 1 5.312 0c.967.052 1.83.585 2.332 1.39l.821 1.317c.24.383.645.643 1.11.71.386.054.77.113 1.152.177 1.432.239 2.429 1.493 2.429 2.909V18a3 3 0 0 1-3 3h-15a3 3 0 0 1-3-3V9.574c0-1.416.997-2.67 2.429-2.909.382-.064.766-.123 1.151-.178a1.56 1.56 0 0 0 1.11-.71l.822-1.315a2.942 2.942 0 0 1 2.332-1.39ZM6.75 12.75a5.25 5.25 0 1 1 10.5 0 5.25 5.25 0 0 1-10.5 0Zm12-1.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
+              </svg>
+            </button>
+            <button class="icon-button" @click="downloadSvg" title="Download SVG">
+              <svg viewBox="0 0 24 24">
+                <path d="M11.25 3h1.5v10.379l3.47-3.47 1.06 1.06-5 5a.75.75 0 0 1-1.06 0l-5-5 1.06-1.06 3.47 3.47V3z"/>
+                <path d="M4.5 18.75h15v1.5h-15z"/>
               </svg>
             </button>
           </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -300,6 +300,7 @@
   </div>
   <script src="assets/js/argon-design-system.min.js"></script>
   <script src="app.js"></script>
+  <script src="src/utils/exportSvg.js"></script>
   <script src="flow.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "test": "node ../backend/node_modules/jest/bin/jest.js",
-    "lint": "eslint app.js flow.js test/**/*.js"
+    "lint": "eslint app.js flow.js src/utils/exportSvg.js test/**/*.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/frontend/src/utils/exportSvg.js
+++ b/frontend/src/utils/exportSvg.js
@@ -1,0 +1,105 @@
+/* global d3 */
+(function (global, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    global.ExportSvg = factory();
+  }
+})(this, function () {
+  function exportFamilyTree({ svgEl, data, colors }) {
+    var d3lib = typeof d3 !== 'undefined' ? d3 : null;
+    if (!d3lib && typeof require === 'function') {
+      try { d3lib = require('d3'); } catch (e) { /* ignore */ }
+    }
+    if (!d3lib) throw new Error('d3 library not found');
+
+    var hierarchy = d3lib.hierarchy;
+    var d3tree = d3lib.tree;
+    var linkHorizontal = d3lib.linkHorizontal;
+    var extent = d3lib.extent;
+    var create = d3lib.create;
+
+    var svg;
+    if (svgEl) {
+      svg = svgEl.cloneNode(true);
+      var bb = svg.getBBox();
+      svg.setAttribute('viewBox', bb.x + ' ' + bb.y + ' ' + bb.width + ' ' + bb.height);
+      svg.setAttribute('width', bb.width);
+      svg.setAttribute('height', bb.height);
+    } else if (data) {
+      var root = hierarchy(data);
+      var layout = d3tree().nodeSize([120, 160]);
+      layout(root);
+      var nodes = root.descendants();
+      var links = root.links();
+      var extX = extent(nodes, function (d) { return d.x; });
+      var extY = extent(nodes, function (d) { return d.y; });
+      var minX = extX[0];
+      var maxX = extX[1];
+      var minY = extY[0];
+      var maxY = extY[1];
+      var pad = 20;
+      var w = maxX - minX + pad * 2;
+      var h = maxY - minY + pad * 2;
+      svg = create('svg')
+        .attr('xmlns', 'http://www.w3.org/2000/svg')
+        .attr('width', w)
+        .attr('height', h)
+        .attr('viewBox', (minX - pad) + ' ' + (minY - pad) + ' ' + w + ' ' + h);
+
+      svg.append('g')
+        .attr('fill', 'none')
+        .attr('stroke', '#555')
+        .attr('stroke-width', 2)
+        .selectAll('path')
+        .data(links)
+        .join('path')
+        .attr('d', linkHorizontal()
+          .x(function (d) { return d.source.x; })
+          .y(function (d) { return d.source.y; })
+          .source(function (d) { return { x: d.source.x, y: d.source.y }; })
+          .target(function (d) { return { x: d.target.x, y: d.target.y }; }));
+
+      var nodeG = svg.append('g').attr('stroke', '#333').attr('stroke-width', 1);
+      var node = nodeG.selectAll('g')
+        .data(nodes)
+        .join('g')
+        .attr('transform', function (d) { return 'translate(' + d.x + ',' + d.y + ')'; });
+
+      node.append('circle')
+        .attr('r', 30)
+        .attr('fill', function (d) { return colors[d.data.gender] || colors['?']; });
+
+      node.append('text')
+        .attr('text-anchor', 'middle')
+        .attr('font-family', 'sans-serif')
+        .attr('font-size', 12)
+        .attr('fill', '#fff')
+        .selectAll('tspan')
+        .data(function (d) {
+          var born = d.data.dateOfBirth ? String(d.data.dateOfBirth).slice(0, 4) : '';
+          var died = d.data.dateOfDeath ? String(d.data.dateOfDeath).slice(0, 4) : '';
+          return [d.data.firstName + ' ' + d.data.lastName, born + '\u2013' + died];
+        })
+        .join('tspan')
+        .attr('x', 0)
+        .attr('y', function (_, i) { return i * 14 - 6; })
+        .text(function (s) { return s; });
+    } else {
+      throw new Error('exportFamilyTree: supply either svgEl or data');
+    }
+
+    var serialised = new XMLSerializer().serializeToString(svg.node ? svg.node() : svg);
+    var blob = new Blob([serialised], { type: 'image/svg+xml;charset=utf-8' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'BlauClan-' + Date.now() + '.svg';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  return { exportFamilyTree: exportFamilyTree };
+});

--- a/frontend/test/exportSvg.test.js
+++ b/frontend/test/exportSvg.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const vm = require('vm');
+
+describe('exportSvg.js syntax', () => {
+  test('file parses without error', () => {
+    const code = fs.readFileSync(require.resolve('../src/utils/exportSvg.js'), 'utf8');
+    expect(() => new vm.Script(code)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add ExportSvg utility to create downloadable SVGs
- provide a toolbar button to trigger SVG download
- expose ExportSvg as global and include script in page
- adjust ESLint globals and add tests

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d9a9e1a48330aebd0f4236dce926