### PR TITLE
Fix exportSvg loading

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /usr/share/nginx/html
 # Copy all root level JS, CSS and HTML files so new assets don't require Dockerfile changes.
 COPY *.html *.js *.css ./
 COPY assets ./assets
+COPY src ./src
 COPY default.conf.template /etc/nginx/conf.d/default.conf.template
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- ensure `src/utils/exportSvg.js` is included in frontend Docker image

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849e32967ec8330b31efbe2b01599ee