### PR TITLE
Add frontend exposure test for assignGenerations

### DIFF
--- a/docs/smart-generation-layout.md
+++ b/docs/smart-generation-layout.md
@@ -1,0 +1,116 @@
+# Smarter Tidy-Up Pass
+
+This document describes a D3-based layout algorithm that keeps spouses and their siblings aligned on the same generation row, even when parent records are missing.
+
+## Why the Original Approach Fails
+
+D3's `tree()` layout determines the vertical coordinate based solely on the distance to a synthetic root. If one spouse has known parents while the other does not, the couple ends up at different depths. They appear on separate rows even though they belong to the same generation.
+
+## High-Level Strategy
+
+1. **Collapse generation-equivalent people into groups**
+   - Two people belong to the same **GenGroup** if they are married or share at least one parent.
+2. **Assign an integer generation to each GenGroup**
+   - A group's generation equals `max(parent groups) + 1`.
+   - When parent information is missing, spouse or sibling links pull members to the correct row.
+3. **Run `d3.tree()` for horizontal spacing**
+   - After `tree()` computes the x‑coordinate, overwrite `y` with `gen × rowHeight`.
+4. **Optional marriage nodes**
+   - Insert invisible nodes per couple so children connect to the midpoint between parents and avoid "V" shapes.
+
+## Detailed Algorithm
+
+### Types
+
+```ts
+interface Person {
+  id: string;
+  motherId?: string;
+  fatherId?: string;
+  spouseIds: string[];
+}
+
+interface GenGroup {
+  id: number;
+  members: Set<string>;
+}
+```
+
+### Phase 1 – Build Generation-Equivalence Classes
+
+Use a Union–Find structure to merge spouses and siblings:
+
+```ts
+class UnionFind {
+  parent = new Map<string, string>();
+  find(x: string): string { /* path compression */ }
+  union(a: string, b: string) { /* union by rank */ }
+}
+```
+
+1. Create singleton sets for all persons.
+2. Union siblings that share at least one parent.
+3. Union all spouse pairs.
+4. Convert the disjoint sets to `GenGroup` objects.
+
+### Phase 2 – Assign Generation Numbers
+
+1. Construct a DAG of GenGroups, where edges point from parent groups to child groups.
+2. Perform a topological longest-path pass to assign generation indices.
+3. Unconnected groups default to generation 0.
+4. Propagate the generation number to every person.
+
+### Phase 3 – Layout With D3
+
+1. Build a tree with any convenient root (possibly a fake root).
+2. Run `d3.tree()` for x-positions.
+3. Set `y = generation * rowHeight` when rendering nodes.
+
+### Phase 4 – Marriage Dummy Nodes (Optional)
+
+Create a synthetic node for each spouse pair:
+
+- ID format: `marriage:a:b`.
+- Children: all biological children of the couple.
+- Parents: the parents of either spouse, or the fake root if unknown.
+
+Link the real spouses as side-by-side children of this dummy node to center them above their children.
+
+## Complexity Overview
+
+| Step | Time | Space |
+|------|------|-------|
+| Union–Find | O(n α(n)) | O(n) |
+| Build edges | O(e) | O(n) |
+| Topological layering | O(n + e) | O(n) |
+| D3 `tree()` | O(n) | O(n) |
+
+Here `α(n)` is the inverse Ackermann function, effectively constant for practical input sizes.
+
+## TypeScript Helper
+
+Implement phases 1 and 2 as a reusable function:
+
+```ts
+export function assignGenerations(persons: Person[]): Map<string, number> {
+  // ...implementation of grouping and generation assignment...
+}
+```
+
+Example usage:
+
+```ts
+const gen = assignGenerations(store.members);
+const layout = tree<Person>().size([width, 1])(hierarchy(fakeRoot));
+svg.selectAll('g.person')
+   .data(layout.descendants())
+   .attr('transform', d => `translate(${d.x}, ${gen.get(d.data.id)! * rowH})`);
+```
+
+## Benefits
+
+- Spouses and siblings always share a row.
+- No external dependencies beyond TypeScript and D3.
+- Runs in linear time even for large trees.
+- Easy to extend for half-siblings, adoptive links, or birth-year heuristics.
+

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -5,7 +5,7 @@
     global.FlowApp = factory();
   }
 })(this, function () {
-  /* global html2canvas, d3 */
+  /* global html2canvas, d3, GenerationLayout */
   function debounce(fn, delay) {
     let t;
     return function (...args) {
@@ -757,15 +757,17 @@
             if (n.motherId && map.has(n.motherId)) map.get(n.motherId).children.push(n);
             if (n.fatherId && map.has(n.fatherId)) map.get(n.fatherId).children.push(n);
           });
+
+          const gen = GenerationLayout.assignGenerations(list);
+          const ROW_HEIGHT = 230;
+
           const roots = [];
           map.forEach((n) => {
             const hasParent = list.some((p) => p.id === n.motherId || p.id === n.fatherId);
             if (!hasParent && n.children.length) roots.push(n);
           });
           const fakeRoot = { id: 'root', children: roots };
-          const layout = d3
-            .tree()
-            .nodeSize([200, 230]);
+          const layout = d3.tree().nodeSize([200, 1]);
           layout(d3.hierarchy(fakeRoot));
 
           fakeRoot.children.forEach(walk);
@@ -773,14 +775,15 @@
             const d = map.get(h.data.id);
             if (d) {
               d.x = h.x;
-              d.y = h.y;
             }
             h.children && h.children.forEach(walk);
           }
+
           list.forEach((n) => {
             const p = map.get(n.id);
             n.x = p.x;
-            n.y = p.y;
+            const g = gen.get(n.id) ?? 0;
+            n.y = g * ROW_HEIGHT;
           });
         }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -301,6 +301,7 @@
   <script src="assets/js/argon-design-system.min.js"></script>
   <script src="app.js"></script>
   <script src="src/utils/exportSvg.js"></script>
+  <script src="src/utils/assignGenerations.js"></script>
   <script src="flow.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "test": "node ../backend/node_modules/jest/bin/jest.js",
-    "lint": "eslint app.js flow.js src/utils/exportSvg.js test/**/*.js"
+    "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js test/**/*.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/frontend/src/utils/assignGenerations.js
+++ b/frontend/src/utils/assignGenerations.js
@@ -1,0 +1,155 @@
+(function (global, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    global.GenerationLayout = factory();
+  }
+})(this, function () {
+  class UnionFind {
+    constructor(ids) {
+      this.parent = new Map();
+      this.rank = new Map();
+      ids.forEach((id) => {
+        this.parent.set(id, id);
+        this.rank.set(id, 0);
+      });
+    }
+    find(x) {
+      let p = this.parent.get(x);
+      if (p === undefined) return undefined;
+      if (p !== x) {
+        p = this.find(p);
+        this.parent.set(x, p);
+      }
+      return p;
+    }
+    union(a, b) {
+      const rootA = this.find(a);
+      const rootB = this.find(b);
+      if (rootA === undefined || rootB === undefined) return;
+      if (rootA === rootB) return;
+      let rankA = this.rank.get(rootA);
+      let rankB = this.rank.get(rootB);
+      if (rankA < rankB) {
+        this.parent.set(rootA, rootB);
+      } else if (rankA > rankB) {
+        this.parent.set(rootB, rootA);
+      } else {
+        this.parent.set(rootB, rootA);
+        this.rank.set(rootA, rankA + 1);
+      }
+    }
+  }
+
+  function assignGenerations(persons) {
+    const ids = persons.map((p) => p.id);
+    const uf = new UnionFind(ids);
+
+    const byMother = new Map();
+    const byFather = new Map();
+
+    persons.forEach((p) => {
+      if (p.motherId) {
+        if (!byMother.has(p.motherId)) byMother.set(p.motherId, []);
+        byMother.get(p.motherId).push(p.id);
+      }
+      if (p.fatherId) {
+        if (!byFather.has(p.fatherId)) byFather.set(p.fatherId, []);
+        byFather.get(p.fatherId).push(p.id);
+      }
+    });
+
+    const unionSiblings = (map) => {
+      map.forEach((children) => {
+        for (let i = 1; i < children.length; i++) {
+          uf.union(children[0], children[i]);
+        }
+      });
+    };
+
+    unionSiblings(byMother);
+    unionSiblings(byFather);
+
+    persons.forEach((p) => {
+      (p.spouseIds || []).forEach((s) => {
+        uf.union(p.id, s);
+      });
+    });
+
+    const repToMembers = new Map();
+    persons.forEach((p) => {
+      const root = uf.find(p.id);
+      if (!repToMembers.has(root)) repToMembers.set(root, new Set());
+      repToMembers.get(root).add(p.id);
+    });
+
+    const groupOfRoot = new Map();
+    let idx = 0;
+    repToMembers.forEach((members, root) => {
+      groupOfRoot.set(root, idx++);
+    });
+
+    const personGroup = new Map();
+    repToMembers.forEach((members, root) => {
+      const gid = groupOfRoot.get(root);
+      members.forEach((id) => personGroup.set(id, gid));
+    });
+
+    const dag = new Map();
+    for (let i = 0; i < idx; i++) {
+      dag.set(i, { children: new Set(), indegree: 0, generation: undefined });
+    }
+
+    persons.forEach((child) => {
+      ['motherId', 'fatherId'].forEach((key) => {
+        const pid = child[key];
+        if (!pid) return;
+        const pg = personGroup.get(pid);
+        const cg = personGroup.get(child.id);
+        if (pg === undefined || cg === undefined || pg === cg) return;
+        const parentNode = dag.get(pg);
+        const childNode = dag.get(cg);
+        if (!parentNode.children.has(cg)) {
+          parentNode.children.add(cg);
+          childNode.indegree++;
+        }
+      });
+    });
+
+    const queue = [];
+    dag.forEach((node, gid) => {
+      if (node.indegree === 0) {
+        node.generation = 0;
+        queue.push(gid);
+      }
+    });
+
+    while (queue.length) {
+      const gid = queue.shift();
+      const node = dag.get(gid);
+      node.children.forEach((cId) => {
+        const child = dag.get(cId);
+        const gen = (node.generation || 0) + 1;
+        if (child.generation === undefined || gen > child.generation) {
+          child.generation = gen;
+        }
+        child.indegree--;
+        if (child.indegree === 0) queue.push(cId);
+      });
+    }
+
+    dag.forEach((node) => {
+      if (node.generation === undefined) node.generation = 0;
+    });
+
+    const result = new Map();
+    persons.forEach((p) => {
+      const gid = personGroup.get(p.id);
+      result.set(p.id, dag.get(gid).generation);
+    });
+
+    return result;
+  }
+
+  return { assignGenerations };
+});

--- a/frontend/test/generation.test.js
+++ b/frontend/test/generation.test.js
@@ -1,0 +1,35 @@
+const { assignGenerations } = require('../src/utils/assignGenerations');
+
+describe('assignGenerations', () => {
+  test('computes generation numbers', () => {
+    const persons = [
+      { id: 'a', spouseIds: ['b'] },
+      { id: 'b', fatherId: 'c', motherId: 'd', spouseIds: ['a'] },
+      { id: 'c', spouseIds: ['d'] },
+      { id: 'd', spouseIds: ['c'] },
+      { id: 'e', fatherId: 'a', motherId: 'b', spouseIds: [] },
+    ];
+    const gen = assignGenerations(persons);
+    expect(gen.get('c')).toBe(0);
+    expect(gen.get('d')).toBe(0);
+    expect(gen.get('a')).toBe(1);
+    expect(gen.get('b')).toBe(1);
+    expect(gen.get('e')).toBe(2);
+  });
+
+  test('available on window when loaded via script tag', () => {
+    const fs = require('fs');
+    const vm = require('vm');
+    const code = fs.readFileSync(require.resolve('../src/utils/assignGenerations.js'), 'utf8');
+    const sandbox = { window: {}, console };
+    vm.runInNewContext(code, sandbox);
+    const api = sandbox.GenerationLayout || sandbox.window.GenerationLayout;
+    expect(typeof api).toBe('object');
+    const gen = api.assignGenerations([
+      { id: 'x', spouseIds: ['y'] },
+      { id: 'y', spouseIds: ['x'] },
+    ]);
+    expect(gen.get('x')).toBe(0);
+    expect(gen.get('y')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test ensuring `assignGenerations` attaches to `window` when loaded in the browser

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849dc23c6248330bcf5cbf4882565b2