### PR TITLE
Fix path export for d3 links

### DIFF
--- a/frontend/src/utils/exportSvg.js
+++ b/frontend/src/utils/exportSvg.js
@@ -55,10 +55,10 @@
         .data(links)
         .join('path')
         .attr('d', linkHorizontal()
-          .x(function (d) { return d.source.x; })
-          .y(function (d) { return d.source.y; })
-          .source(function (d) { return { x: d.source.x, y: d.source.y }; })
-          .target(function (d) { return { x: d.target.x, y: d.target.y }; }));
+          .x(function (d) { return d.x; })
+          .y(function (d) { return d.y; })
+          .source(function (d) { return d.source; })
+          .target(function (d) { return d.target; }));
 
       var nodeG = svg.append('g').attr('stroke', '#333').attr('stroke-width', 1);
       var node = nodeG.selectAll('g')


### PR DESCRIPTION
## Summary
- fix `exportSvg` link generator

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849e63d7a888330bcc7e7b1f01dba48