### PR TITLE
Fix layout tidyUp error

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -773,9 +773,10 @@
           });
           const fakeRoot = { id: 'root', children: roots };
           const layout = d3.tree().nodeSize([200, 1]);
-          layout(d3.hierarchy(fakeRoot));
+          const rootNode = d3.hierarchy(fakeRoot);
+          layout(rootNode);
 
-          fakeRoot.children.forEach(walk);
+          rootNode.children.forEach(walk);
           function walk(h) {
             const d = map.get(h.data.id);
             if (d) {


### PR DESCRIPTION
## Summary
- prevent TypeError in tidyUp by using hierarchy nodes

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849e7d801548330a2134d5b8134fd41