### PR TITLE
Improve multi-selection UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,6 +113,30 @@
     .faded-edge .vue-flow__edge-path {
       opacity: 0.3;
     }
+    .vue-flow__nodesselection-rect {
+      border: 1px dashed #3b82f6;
+      background: rgba(59, 130, 246, 0.1);
+    }
+    .vue-flow__node.selected .person-node {
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 2px #3b82f6;
+    }
+    body.multi-select-active #flow-app {
+      cursor: crosshair;
+    }
+    #multiIndicator {
+      position: absolute;
+      top: 10px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: rgba(59,130,246,0.9);
+      color: #fff;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      z-index: 20;
+      display: none;
+    }
     .modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center; }
     .modal-content {
       background: #fff;
@@ -293,7 +317,9 @@
         </div>
       </div>
     </div>
-        <div id="flow-app" style="touch-action: none; overflow: hidden;"></div>
+        <div id="flow-app" style="touch-action: none; overflow: hidden;">
+          <div id="multiIndicator">Multi-select</div>
+        </div>
       </div>
     </div>
     <footer id="footer" class="text-center py-2">&copy; BlauCity 2025</footer>


### PR DESCRIPTION
## Summary
- style selection rectangle and selected nodes
- show indicator when Shift is pressed
- allow shift-click to toggle node selection
- prevent helper nodes from being dragged

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c812e7c2083308c36ae604d7a669d