### PR TITLE
Add database backup endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,7 @@ to display.
 - `DELETE /api/people/:id/spouses/:marriageId`
 - `GET /api/tree/:id` – query param `type` can be `ancestors`, `descendants`, or `both`
 - `GET /api/export/json`
+- `GET /api/export/db`
+- `POST /api/import/db`
 
 This is an early version and subject to change.


### PR DESCRIPTION
## Summary
- support exporting/importing complete DB via `/api/export/db` and `/api/import/db`
- document new routes in README
- test round‐trip import/export functionality

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c81da5d6c8330bde9f49823793444