### PR TITLE
Fix context menu position relative to canvas

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -906,8 +906,11 @@
 
        function openContextMenu(ev) {
          const point = ev.touches ? ev.touches[0] : ev;
-         contextX.value = point.clientX;
-         contextY.value = point.clientY;
+         const rect = document
+           .getElementById('flow-app')
+           .getBoundingClientRect();
+         contextX.value = point.clientX - rect.left;
+         contextY.value = point.clientY - rect.top;
          contextMenuVisible.value = true;
        }
 


### PR DESCRIPTION
## Summary
- adjust context menu coordinates to account for the flow canvas offset

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c87a1b21883309b95d6160adb0ffa