### PR TITLE
Add workflow for Portainer redeploy

### DIFF
--- a/.github/workflows/portainer-redeploy.yml
+++ b/.github/workflows/portainer-redeploy.yml
@@ -1,0 +1,31 @@
+name: Trigger Portainer Deploy via n8n
+
+on:
+  push:
+    branches: [main, develop]
+
+jobs:
+  notify-n8n:
+    runs-on: ubuntu-latest
+    container:
+      image: curlimages/curl:latest
+
+    steps:
+      - name: Determine and Trigger
+        env:
+          WEBHOOK_URL: ${{ secrets.N8N_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.N8N_WEBHOOK_SECRET }}
+        run: |
+          if [[ "${GITHUB_REF##*/}" == "main" ]]; then
+            STACK_ID=139
+          elif [[ "${GITHUB_REF##*/}" == "develop" ]]; then
+            STACK_ID=140
+          else
+            echo "No action for branch ${GITHUB_REF##*/}"
+            exit 0
+          fi
+
+          curl -X POST "$WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -H "x-n8n-secret: $WEBHOOK_SECRET" \
+            -d "{\"stack_id\": $STACK_ID}"


### PR DESCRIPTION
## Summary
- trigger n8n webhook on pushes to main or develop using `curl`

## Testing
- `npm run lint` && `npm test` in `backend`
- `npm run lint` && `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684d86692c7c83309c000e1ab2673180