### PR TITLE
Adjust horizontal grid size

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -34,7 +34,14 @@
           snapToGrid,
           snapGrid,
         } = useVueFlow();
-        const gridSize = (window.AppConfig && AppConfig.gridSize) || 30;
+        const horizontalGridSize =
+          (window.AppConfig &&
+            (AppConfig.horizontalGridSize || AppConfig.gridSize)) ||
+          30;
+        const verticalGridSize =
+          (window.AppConfig &&
+            (AppConfig.verticalGridSize || AppConfig.gridSize)) ||
+          30;
         const selected = ref(null);
         const showModal = ref(false);
         const contextMenuVisible = ref(false);
@@ -323,7 +330,7 @@
         onMounted(async () => {
           await load();
           fitView();
-          snapGrid.value = [gridSize, gridSize];
+          snapGrid.value = [horizontalGridSize, verticalGridSize];
           window.addEventListener('keydown', handleKeydown);
           window.addEventListener('keyup', handleKeyup);
         });
@@ -1019,7 +1026,8 @@
         downloadSvg,
         toggleSnap,
         snapToGrid,
-        gridSize,
+        horizontalGridSize,
+        verticalGridSize,
         onNodeDragStop,
         handleContextMenu,
         handleTouchStart,
@@ -1087,7 +1095,7 @@
             :min-zoom="0.1"
             :select-nodes-on-drag="true"
             :snap-to-grid="snapToGrid"
-            :snap-grid="[gridSize, gridSize]"
+            :snap-grid="[horizontalGridSize, verticalGridSize]"
             selection-key-code="Shift"
             multi-selection-key-code="Shift"
           >

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -6,6 +6,9 @@
   }
 })(this, function () {
   return {
-    gridSize: 30
+    // grid size for snapping nodes. horizontalGridSize is slightly
+    // smaller than verticalGridSize to allow tighter horizontal spacing
+    horizontalGridSize: 20,
+    verticalGridSize: 30,
   };
 });


### PR DESCRIPTION
## Summary
- tweak `frontend/src/config.js` to specify separate horizontal/vertical grid sizes
- update `frontend/flow.js` to use new grid settings

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df13baa68833092081333de23b1f1