### PR TITLE
Add call name field

### DIFF
--- a/backend/sample-data.json
+++ b/backend/sample-data.json
@@ -2,18 +2,21 @@
   {
     "id": 1,
     "firstName": "John",
+    "callName": "Johnny",
     "lastName": "Doe",
     "gender": "M"
   },
   {
     "id": 2,
     "firstName": "Jane",
+    "callName": "Janey",
     "lastName": "Smith",
     "gender": "F"
   },
   {
     "id": 3,
     "firstName": "Child",
+    "callName": "Kid",
     "lastName": "Doe",
     "fatherId": 1,
     "motherId": 2,

--- a/backend/src/models/person.js
+++ b/backend/src/models/person.js
@@ -5,6 +5,7 @@ module.exports = (sequelize) => {
     {
       id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
       firstName: DataTypes.STRING,
+      callName: DataTypes.STRING,
       lastName: DataTypes.STRING,
       maidenName: DataTypes.STRING,
       gender: DataTypes.STRING,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -73,7 +73,11 @@
 
   function parentName(id, people) {
     const p = people.find((x) => x.id === id);
-    return p ? `${p.firstName} ${p.lastName}` : '';
+    if (!p) return '';
+    if (p.callName) {
+      return `${p.callName} (${p.firstName}) ${p.lastName}`;
+    }
+    return `${p.firstName} ${p.lastName}`;
   }
 
   function mountApp() {
@@ -140,6 +144,7 @@
           if (!this.selectedPerson) return;
           const payload = {
             firstName: this.selectedPerson.firstName,
+            callName: this.selectedPerson.callName || '',
             lastName: this.selectedPerson.lastName,
             maidenName: this.selectedPerson.maidenName || '',
             dateOfBirth: this.selectedPerson.dateOfBirth || null,

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -696,6 +696,7 @@
 
         function addPerson(pos) {
           selected.value = {
+            callName: '',
             firstName: '',
             lastName: '',
             maidenName: '',
@@ -723,6 +724,7 @@
         function addChild() {
           const base = { ...selected.value };
           selected.value = {
+            callName: '',
             firstName: '',
             lastName: '',
             maidenName: '',
@@ -742,6 +744,7 @@
         function addSpouse() {
           const base = { ...selected.value };
           selected.value = {
+            callName: '',
             firstName: '',
             lastName: '',
             maidenName: '',
@@ -761,6 +764,7 @@
         function addParent(type) {
           const childId = selected.value.id;
           selected.value = {
+            callName: '',
             firstName: '',
             lastName: '',
             maidenName: '',
@@ -944,6 +948,7 @@
 
         async function saveNewPerson() {
           const payload = {
+            callName: selected.value.callName || '',
             firstName: selected.value.firstName,
             lastName: selected.value.lastName,
             maidenName: selected.value.maidenName || null,
@@ -1142,8 +1147,9 @@
                 <div class="header">
                   <img :src="avatarSrc(data.gender, 40)" class="avatar" />
                   <div class="name-container">
-                    <span :style="{ fontSize: data.firstName && data.firstName.length > 12 ? '0.7rem' : '0.8rem', fontWeight: 'bold' }">{{ data.firstName }}</span>
-                    <span :style="{ fontSize: data.lastName && data.lastName.length > 12 ? '0.7rem' : '0.8rem', fontWeight: 'bold' }">{{ data.lastName }}</span>
+                    <span :style="{ fontSize: (data.callName || data.firstName) && (data.callName || data.firstName).length > 12 ? '0.7rem' : '0.8rem', fontWeight: 'bold' }">{{ data.callName || data.firstName }}</span>
+                    <span v-if="data.callName" :style="{ fontSize: data.firstName && data.firstName.length > 12 ? '0.7rem' : '0.8rem' }"> ({{ data.firstName }})</span>
+                    <span :style="{ fontSize: data.lastName && data.lastName.length > 12 ? '0.7rem' : '0.8rem', fontWeight: 'bold' }"> {{ data.lastName }}</span>
                   </div>
                 </div>
                 <div class="small">{{ data.dateOfBirth }}<span v-if="data.dateOfBirth || data.dateOfDeath"> - </span>{{ data.dateOfDeath }}</div>
@@ -1189,7 +1195,8 @@
                   <div class="d-flex align-items-center mb-3">
                     <img :src="avatarSrc(selected.gender, 80)" class="avatar-placeholder mr-3" />
                     <div class="name-container">
-                      <div class="h4 mb-0" :style="{ fontSize: selected.firstName && selected.firstName.length > 15 ? '1rem' : '1.25rem' }">{{ selected.firstName }}</div>
+                      <div class="h4 mb-0" :style="{ fontSize: (selected.callName || selected.firstName) && (selected.callName || selected.firstName).length > 15 ? '1rem' : '1.25rem' }">{{ selected.callName || selected.firstName }}</div>
+                      <div v-if="selected.callName" class="h4 mb-0" :style="{ fontSize: selected.firstName && selected.firstName.length > 15 ? '1rem' : '1.25rem' }">({{ selected.firstName }})</div>
                       <div class="h4 mb-0" :style="{ fontSize: selected.lastName && selected.lastName.length > 15 ? '1rem' : '1.25rem' }">{{ selected.lastName }}</div>
                     </div>
                   </div>
@@ -1205,7 +1212,7 @@
                   <div v-if="children.length" class="mb-2">
                     <strong>Children:</strong>
                     <ul>
-                      <li v-for="c in children" :key="c.id">{{ c.firstName }} {{ c.lastName }}</li>
+                      <li v-for="c in children" :key="c.id">{{ c.callName ? c.callName + ' (' + c.firstName + ')' : c.firstName }} {{ c.lastName }}</li>
                     </ul>
                   </div>
                   <div class="text-right mt-3">
@@ -1217,6 +1224,10 @@
                   <h3 class="card-title" v-if="isNew">Add Person</h3>
                   <h3 class="card-title" v-else>Edit Person</h3>
                   <div class="form-row">
+                    <div class="col d-flex align-items-center mb-2">
+                      <label class="mr-2 mb-0" style="width: 90px;">Call Name</label>
+                      <input class="form-control flex-fill" v-model="selected.callName" placeholder="Enter call name" title="Preferred name" />
+                    </div>
                     <div class="col d-flex align-items-center mb-2">
                       <label class="mr-2 mb-0" style="width: 90px;">First Name</label>
                       <input class="form-control flex-fill" v-model="selected.firstName" placeholder="Enter first name" title="Given name" />
@@ -1260,21 +1271,21 @@
                       <label class="mr-2 mb-0" style="width: 90px;">Father</label>
                       <select class="form-control flex-fill" v-model="selected.fatherId" title="Select father">
                         <option value="">Father</option>
-                        <option v-for="n in nodes" :key="'f'+n.id" :value="n.data.id">{{ n.data.firstName }} {{ n.data.lastName }}</option>
+                        <option v-for="n in nodes" :key="'f'+n.id" :value="n.data.id">{{ n.data.callName ? n.data.callName + ' (' + n.data.firstName + ')' : n.data.firstName }} {{ n.data.lastName }}</option>
                       </select>
                     </div>
                     <div class="d-flex align-items-center mb-2">
                       <label class="mr-2 mb-0" style="width: 90px;">Mother</label>
                       <select class="form-control flex-fill" v-model="selected.motherId" title="Select mother">
                         <option value="">Mother</option>
-                        <option v-for="n in nodes" :key="'m'+n.id" :value="n.data.id">{{ n.data.firstName }} {{ n.data.lastName }}</option>
+                        <option v-for="n in nodes" :key="'m'+n.id" :value="n.data.id">{{ n.data.callName ? n.data.callName + ' (' + n.data.firstName + ')' : n.data.firstName }} {{ n.data.lastName }}</option>
                       </select>
                     </div>
                     <div class="d-flex align-items-center mb-2">
                       <label class="mr-2 mb-0" style="width: 90px;">Spouse</label>
                       <select class="form-control flex-fill" v-model="selected.spouseId" title="Link spouse">
                         <option value="">Spouse</option>
-                        <option v-for="n in nodes" :key="'s'+n.id" :value="n.data.id">{{ n.data.firstName }} {{ n.data.lastName }}</option>
+                        <option v-for="n in nodes" :key="'s'+n.id" :value="n.data.id">{{ n.data.callName ? n.data.callName + ' (' + n.data.firstName + ')' : n.data.firstName }} {{ n.data.lastName }}</option>
                       </select>
                     </div>
                     <div class="d-flex align-items-center mb-2">
@@ -1286,7 +1297,7 @@
                     <label>Children</label>
                     <ul>
                       <li v-for="c in children" :key="c.id">
-                        {{ c.firstName }} {{ c.lastName }}
+                        {{ c.callName ? c.callName + ' (' + c.firstName + ')' : c.firstName }} {{ c.lastName }}
                         <button class="btn btn-sm btn-danger ml-1" @click="unlinkChild(c)">x</button>
                       </li>
                     </ul>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -264,6 +264,10 @@
         <h2>Edit Person</h2>
         <div class="form-row">
           <div class="col">
+            <label>Call Name</label>
+            <input class="form-control mb-2" v-model="selectedPerson.callName" placeholder="Call Name">
+          </div>
+          <div class="col">
             <label>First Name</label>
             <input class="form-control mb-2" v-model="selectedPerson.firstName" placeholder="First Name">
           </div>
@@ -291,12 +295,12 @@
           <label>Father</label>
           <select class="form-control mb-2" v-model="selectedPerson.fatherId">
             <option value="">Father</option>
-            <option v-for="p in availableParentOptions" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
+            <option v-for="p in availableParentOptions" :value="p.id">{{ p.callName ? p.callName + ' (' + p.firstName + ')' : p.firstName }} {{ p.lastName }}</option>
           </select>
           <label>Mother</label>
           <select class="form-control mb-2" v-model="selectedPerson.motherId">
             <option value="">Mother</option>
-            <option v-for="p in availableParentOptions" :value="p.id">{{ p.firstName }} {{ p.lastName }}</option>
+            <option v-for="p in availableParentOptions" :value="p.id">{{ p.callName ? p.callName + ' (' + p.firstName + ')' : p.firstName }} {{ p.lastName }}</option>
           </select>
           <label>Notes</label>
           <textarea class="form-control mb-2" v-model="selectedPerson.notes" placeholder="Notes"></textarea>
@@ -306,14 +310,14 @@
         <div v-if="spouses.length" class="card">
           <h3>Spouses</h3>
           <ul>
-            <li v-for="s in spouses">{{ s.spouse.firstName }} {{ s.spouse.lastName }}</li>
+            <li v-for="s in spouses">{{ s.spouse.callName ? s.spouse.callName + ' (' + s.spouse.firstName + ')' : s.spouse.firstName }} {{ s.spouse.lastName }}</li>
           </ul>
         </div>
         <div v-if="childrenOfSelected.length" class="card">
           <h3>Children</h3>
           <ul>
             <li v-for="c in childrenOfSelected" :key="c.id">
-              {{ c.firstName }} {{ c.lastName }}
+              {{ c.callName ? c.callName + ' (' + c.firstName + ')' : c.firstName }} {{ c.lastName }}
               <button class="btn btn-sm btn-danger ml-1" @click="unlinkChild(c)">x</button>
             </li>
           </ul>

--- a/frontend/test/app.test.js
+++ b/frontend/test/app.test.js
@@ -76,9 +76,13 @@ describe('frontend helpers', () => {
   });
 
   test('parentName formats correctly', () => {
-    const list = [{ id: 1, firstName: 'A', lastName: 'B' }];
-    expect(parentName(1, list)).toBe('A B');
-    expect(parentName(2, list)).toBe('');
+    const list = [
+      { id: 1, firstName: 'A', callName: 'Al', lastName: 'B' },
+      { id: 2, firstName: 'C', lastName: 'D' },
+    ];
+    expect(parentName(1, list)).toBe('Al (A) B');
+    expect(parentName(2, list)).toBe('C D');
+    expect(parentName(3, list)).toBe('');
   });
 
   test('mountApp loads people', async () => {


### PR DESCRIPTION
## Summary
- add `callName` to person model and seed data
- show call name with first name in parentheses on person cards
- capture call name on edit forms and modal dialogs
- update parentName helper and tests
- only show actual first name when no call name

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684df84f02288330b9778ef3b292c432