### PR TITLE
Implement enter shortcut for modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ to display.
 - `POST /api/import/db`
 
 This is an early version and subject to change.
+
+### Keyboard Shortcuts
+
+- **Enter**: When editing a person, press Enter to save changes and close the modal.

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -285,6 +285,16 @@
           if (ev.key === 'Shift') {
             shiftPressed.value = true;
           }
+          if (ev.key === 'Enter' && editing.value && showModal.value) {
+            ev.preventDefault();
+            if (isNew.value) {
+              saveNewPerson();
+            } else {
+              saveSelected();
+            }
+            cancelModal();
+            return;
+          }
           if (ev.shiftKey && ev.altKey && ev.key.toLowerCase() === 't') {
             ev.preventDefault();
             tidyUpLayout();


### PR DESCRIPTION
## Summary
- allow pressing Enter to close edit modal and save data
- document Enter keyboard shortcut

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e942a155c83308310691861fbbc82