### PR TITLE
Update input mask and modal behavior

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1006,6 +1006,15 @@
          editing.value = false;
        }
 
+       function overlayClose() {
+         if (isNew.value) {
+           saveNewPerson();
+         } else {
+           if (editing.value) saveSelected();
+           cancelModal();
+         }
+       }
+
        function openContextMenu(ev) {
          const point = ev.touches ? ev.touches[0] : ev;
          const rect = document
@@ -1091,6 +1100,7 @@
         menuAdd,
         menuTidy,
         menuFit,
+        overlayClose,
       };
       },
       template: `
@@ -1190,7 +1200,7 @@
             <li @click="menuFit">Zoom to Fit</li>
           </ul>
 
-          <div v-if="showModal" class="modal">
+          <div v-if="showModal" class="modal" @click.self="overlayClose">
             <div
               class="modal-content card shadow border-0"
               :style="{
@@ -1271,20 +1281,22 @@
                       <input class="form-control flex-fill" v-model="selected.dateOfBirth" type="date" title="Birth date" />
                     </div>
                     <div class="col d-flex align-items-center mb-2">
+                      <label class="mr-2 mb-0" style="width: 90px;">Date of Death</label>
+                      <input class="form-control flex-fill" v-model="selected.dateOfDeath" type="date" title="Death date" />
+                    </div>
+                  </div>
+                  <div class="form-row">
+                    <div class="col d-flex align-items-center mb-2">
                       <label class="mr-2 mb-0" style="width: 90px;">Place of Birth</label>
                       <input class="form-control flex-fill" v-model="selected.placeOfBirth" placeholder="City or town" title="Place of birth" />
+                    </div>
+                    <div class="col d-flex align-items-center mb-2">
+                      <label class="mr-2 mb-0" style="width: 90px;">Maiden Name</label>
+                      <input class="form-control flex-fill" v-model="selected.maidenName" placeholder="Birth surname" title="Maiden name" />
                     </div>
                   </div>
                   <button class="btn btn-link p-0 mb-2" type="button" data-toggle="collapse" data-target="#modalDetails">More Details</button>
                   <div id="modalDetails" class="collapse">
-                    <div class="d-flex align-items-center mb-2">
-                      <label class="mr-2 mb-0" style="width: 90px;">Maiden Name</label>
-                      <input class="form-control flex-fill" v-model="selected.maidenName" placeholder="Birth surname" title="Maiden name" />
-                    </div>
-                    <div class="d-flex align-items-center mb-2">
-                      <label class="mr-2 mb-0" style="width: 90px;">Date of Death</label>
-                      <input class="form-control flex-fill" v-model="selected.dateOfDeath" type="date" title="Death date" />
-                    </div>
                     <div class="d-flex align-items-center mb-2">
                       <label class="mr-2 mb-0" style="width: 90px;">Father</label>
                       <select class="form-control flex-fill" v-model="selected.fatherId" title="Select father">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -282,16 +282,22 @@
             <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfBirth" placeholder="DoB">
           </div>
           <div class="col">
+            <label>Date of Death</label>
+            <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfDeath" placeholder="DoD">
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="col">
             <label>Place of Birth</label>
             <input class="form-control mb-2" v-model="selectedPerson.placeOfBirth" placeholder="Place of Birth">
+          </div>
+          <div class="col">
+            <label>Maiden Name</label>
+            <input class="form-control mb-2" v-model="selectedPerson.maidenName" placeholder="Maiden Name">
           </div>
         </div>
         <button class="btn btn-link p-0 mb-2" type="button" data-toggle="collapse" data-target="#editDetails">More Details</button>
         <div id="editDetails" class="collapse">
-          <label>Maiden Name</label>
-          <input class="form-control mb-2" v-model="selectedPerson.maidenName" placeholder="Maiden Name">
-          <label>Date of Death</label>
-          <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfDeath" placeholder="DoD">
           <label>Father</label>
           <select class="form-control mb-2" v-model="selectedPerson.fatherId">
             <option value="">Father</option>


### PR DESCRIPTION
## Summary
- promote maiden name and date of death to the main person edit fields
- rearrange modal fields accordingly
- allow closing the modal by clicking outside the content area and auto-save

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e966e2c848330a6fd535ddf7f36d9