### PR TITLE
Fix GEDCOM import and store marriage details

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -69,7 +69,13 @@ app.get('/api/people/:id/spouses', async (req, res) => {
     const spouseId = m.personId == id ? m.spouseId : m.personId;
     const spouse = await Person.findByPk(spouseId);
     if (spouse) {
-      result.push({ marriageId: m.id, dateOfMarriage: m.dateOfMarriage, spouse });
+      result.push({
+        marriageId: m.id,
+        dateOfMarriage: m.dateOfMarriage,
+        marriageApprox: m.marriageApprox,
+        placeOfMarriage: m.placeOfMarriage,
+        spouse,
+      });
     }
   }
   res.json(result);
@@ -85,6 +91,8 @@ app.post('/api/people/:id/spouses', async (req, res) => {
       personId: id,
       spouseId,
       dateOfMarriage: req.body.dateOfMarriage,
+      marriageApprox: req.body.marriageApprox,
+      placeOfMarriage: req.body.placeOfMarriage,
     });
     res.status(201).json(marriage);
   } catch (err) {
@@ -149,6 +157,8 @@ async function buildDescendants(id) {
     node.spouseRelationships.push({
       spouse: spouse.toJSON(),
       dateOfMarriage: m.dateOfMarriage,
+      marriageApprox: m.marriageApprox,
+      placeOfMarriage: m.placeOfMarriage,
       children: childNodes,
     });
   }

--- a/backend/src/models/marriage.js
+++ b/backend/src/models/marriage.js
@@ -7,6 +7,8 @@ module.exports = (sequelize) => {
       personId: { type: DataTypes.INTEGER, allowNull: false },
       spouseId: { type: DataTypes.INTEGER, allowNull: false },
       dateOfMarriage: DataTypes.DATEONLY,
+      marriageApprox: DataTypes.STRING,
+      placeOfMarriage: DataTypes.STRING,
     },
     { sequelize, modelName: 'Marriage' }
   );

--- a/backend/src/models/person.js
+++ b/backend/src/models/person.js
@@ -16,6 +16,7 @@ module.exports = (sequelize) => {
       placeOfBirth: DataTypes.STRING,
       notes: DataTypes.TEXT,
       avatarUrl: DataTypes.STRING,
+      gedcomId: DataTypes.STRING,
       fatherId: { type: DataTypes.INTEGER, allowNull: true },
       motherId: { type: DataTypes.INTEGER, allowNull: true },
     },

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -42,11 +42,16 @@
     }
   }
 
-  async function linkSpouse(personId, spouseId) {
+  async function linkSpouse(personId, spouseId, options = {}) {
     const res = await fetch(`/api/people/${personId}/spouses`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ spouseId }),
+      body: JSON.stringify({
+        spouseId,
+        dateOfMarriage: options.dateOfMarriage,
+        marriageApprox: options.marriageApprox,
+        placeOfMarriage: options.placeOfMarriage,
+      }),
     });
     if (!res.ok) {
       throw new Error('Failed to link spouse');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -316,7 +316,15 @@
         <div v-if="spouses.length" class="card">
           <h3>Spouses</h3>
           <ul>
-            <li v-for="s in spouses">{{ s.spouse.callName ? s.spouse.callName + ' (' + s.spouse.firstName + ')' : s.spouse.firstName }} {{ s.spouse.lastName }}</li>
+            <li v-for="s in spouses">
+              {{ s.spouse.callName ? s.spouse.callName + ' (' + s.spouse.firstName + ')' : s.spouse.firstName }} {{ s.spouse.lastName }}
+              <span v-if="s.dateOfMarriage || s.marriageApprox || s.placeOfMarriage" class="text-muted">
+                -
+                <span v-if="s.dateOfMarriage">{{ s.dateOfMarriage }}</span>
+                <span v-else-if="s.marriageApprox">{{ s.marriageApprox }}</span>
+                <span v-if="s.placeOfMarriage">@ {{ s.placeOfMarriage }}</span>
+              </span>
+            </li>
           </ul>
         </div>
         <div v-if="childrenOfSelected.length" class="card">

--- a/frontend/test/app.test.js
+++ b/frontend/test/app.test.js
@@ -46,8 +46,15 @@ describe('frontend helpers', () => {
 
   test('linkSpouse posts relationship', async () => {
     global.fetch.mockResolvedValue({ ok: true, json: () => ({ id: 1 }) });
-    await linkSpouse(1, 2);
-    expect(global.fetch).toHaveBeenCalledWith('/api/people/1/spouses', expect.objectContaining({ method: 'POST' }));
+    await linkSpouse(1, 2, { dateOfMarriage: '2000-01-01', placeOfMarriage: 'X' });
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/people/1/spouses',
+      expect.objectContaining({ method: 'POST' })
+    );
+    const [, opts] = global.fetch.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.placeOfMarriage).toBe('X');
+    expect(body.dateOfMarriage).toBe('2000-01-01');
   });
 
   test('fetchSpouses gets list', async () => {

--- a/frontend/test/gedcom.test.js
+++ b/frontend/test/gedcom.test.js
@@ -3,18 +3,31 @@ const { parseGedcom } = require('../src/utils/gedcom');
 describe('parseGedcom', () => {
   test('parses simple individual', () => {
     const text = '0 @I1@ INDI\n1 NAME Anna /Smith/\n1 SEX F\n1 BIRT\n2 DATE 1 JAN 1900';
-    const people = parseGedcom(text);
-    expect(people).toHaveLength(1);
-    expect(people[0].firstName).toBe('Anna');
-    expect(people[0].lastName).toBe('Smith');
-    expect(people[0].gender).toBe('female');
-    expect(people[0].dateOfBirth).toBe('1900-01-01');
+    const res = parseGedcom(text);
+    expect(res.people).toHaveLength(1);
+    expect(res.people[0].gedcomId).toBe('@I1@');
+    expect(res.people[0].firstName).toBe('Anna');
+    expect(res.people[0].lastName).toBe('Smith');
+    expect(res.people[0].gender).toBe('female');
+    expect(res.people[0].dateOfBirth).toBe('1900-01-01');
   });
 
   test('handles approximate date', () => {
     const text = '0 @I1@ INDI\n1 NAME Bob /Jones/\n1 BIRT\n2 DATE ABT 1800';
-    const [p] = parseGedcom(text);
+    const { people } = parseGedcom(text);
+    const p = people[0];
     expect(p.birthApprox).toBe('ABT 1800');
     expect(p.dateOfBirth).toBeUndefined();
+  });
+
+  test('parses family relationships', () => {
+    const text = '0 @I1@ INDI\n1 NAME A /B/\n0 @I2@ INDI\n1 NAME C /D/\n0 @F1@ FAM\n1 HUSB @I1@\n1 WIFE @I2@\n1 MARR\n2 DATE 13 APR 1706\n2 PLAC Graben';
+    const { families } = parseGedcom(text);
+    expect(families).toHaveLength(1);
+    const fam = families[0];
+    expect(fam.husband).toBe('@I1@');
+    expect(fam.wife).toBe('@I2@');
+    expect(fam.date).toBe('1706-04-13');
+    expect(fam.place).toBe('Graben');
   });
 });


### PR DESCRIPTION
## Summary
- add `gedcomId` to people schema
- allow marriages to store approximate date and place
- parse GEDCOM families and keep IDs
- import GEDCOM relationships and avoid duplicates
- show marriage info in spouse list

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f209c01ec8330b9bcf37fe366ad16