### PR TITLE
Display approximate life dates in tree

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1286,7 +1286,12 @@
                     <span :style="{ fontSize: data.lastName && data.lastName.length > 12 ? '0.7rem' : '0.8rem', fontWeight: 'bold' }"> {{ data.lastName }}</span>
                   </div>
                 </div>
-                <div class="small">{{ data.dateOfBirth }}<span v-if="data.dateOfBirth || data.dateOfDeath"> - </span>{{ data.dateOfDeath }}</div>
+                <div class="small">
+                  {{ data.dateOfBirth || data.birthApprox }}<span
+                    v-if="(data.dateOfBirth || data.birthApprox) || (data.dateOfDeath || data.deathApprox)"
+                    > - </span
+                  >{{ data.dateOfDeath || data.deathApprox }}
+                </div>
                 <Handle type="source" position="top" id="s-top" />
                 <Handle type="source" position="right" id="s-right" />
                 <Handle type="source" position="bottom" id="s-bottom" />
@@ -1361,11 +1366,28 @@
                     </div>
                   </div>
                   <p v-if="selected.maidenName"><strong>Maiden Name:</strong> {{ selected.maidenName }}</p>
-                  <p v-if="selected.dateOfBirth || selected.dateOfDeath">
+                  <p
+                    v-if="
+                      selected.dateOfBirth ||
+                      selected.birthApprox ||
+                      selected.dateOfDeath ||
+                      selected.deathApprox
+                    "
+                  >
                     <strong>Life:</strong>
-                    <span v-if="selected.dateOfBirth">{{ selected.dateOfBirth }}</span>
-                    <span v-if="selected.dateOfBirth || selected.dateOfDeath"> - </span>
-                    <span v-if="selected.dateOfDeath">{{ selected.dateOfDeath }}</span>
+                    <span v-if="selected.dateOfBirth || selected.birthApprox"
+                      >{{ selected.dateOfBirth || selected.birthApprox }}</span
+                    >
+                    <span
+                      v-if="
+                        (selected.dateOfBirth || selected.birthApprox) ||
+                        (selected.dateOfDeath || selected.deathApprox)
+                      "
+                      > - </span
+                    >
+                    <span v-if="selected.dateOfDeath || selected.deathApprox"
+                      >{{ selected.dateOfDeath || selected.deathApprox }}</span
+                    >
                   </p>
                   <p v-if="selected.placeOfBirth"><strong>Place of Birth:</strong> {{ selected.placeOfBirth }}</p>
                   <p v-if="selected.notes"><strong>Notes:</strong> {{ selected.notes }}</p>

--- a/frontend/src/utils/exportSvg.js
+++ b/frontend/src/utils/exportSvg.js
@@ -77,8 +77,12 @@
         .attr('fill', '#fff')
         .selectAll('tspan')
         .data(function (d) {
-          var born = d.data.dateOfBirth ? String(d.data.dateOfBirth).slice(0, 4) : '';
-          var died = d.data.dateOfDeath ? String(d.data.dateOfDeath).slice(0, 4) : '';
+          var born = '';
+          if (d.data.dateOfBirth) born = String(d.data.dateOfBirth).slice(0, 4);
+          else if (d.data.birthApprox) born = d.data.birthApprox;
+          var died = '';
+          if (d.data.dateOfDeath) died = String(d.data.dateOfDeath).slice(0, 4);
+          else if (d.data.deathApprox) died = d.data.deathApprox;
           return [d.data.firstName + ' ' + d.data.lastName, born + '\u2013' + died];
         })
         .join('tspan')


### PR DESCRIPTION
## Summary
- show approximate birth/death dates when exact ones are missing on tree nodes
- display approximate life dates in the person detail view
- include approximate dates when exporting SVG

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f218236f48330b47d78c93c5ba6d7