### PR TITLE
Add select all shortcut and clear canvas option

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -76,6 +76,14 @@
     }
   }
 
+  async function clearDatabase() {
+    await fetch('/api/import/db', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ people: [], marriages: [], layouts: [] }),
+    });
+  }
+
   function parentName(id, people) {
     const p = people.find((x) => x.id === id);
     if (!p) return '';
@@ -180,6 +188,7 @@
     linkSpouse,
     fetchSpouses,
     deleteSpouse,
+    clearDatabase,
     parentName,
     mountApp,
   };

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -306,12 +306,17 @@
             cancelModal();
             return;
           }
-          if (ev.shiftKey && ev.altKey && ev.key.toLowerCase() === 't') {
-            ev.preventDefault();
-            tidyUpLayout();
-            return;
-          }
-          if (ev.key !== 'Delete' || !selectedEdge.value) return;
+        if (ev.shiftKey && ev.altKey && ev.key.toLowerCase() === 't') {
+          ev.preventDefault();
+          tidyUpLayout();
+          return;
+        }
+        if ((ev.metaKey || ev.ctrlKey) && ev.shiftKey && ev.key.toLowerCase() === 'a') {
+          ev.preventDefault();
+          addSelectedNodes(nodes.value);
+          return;
+        }
+        if (ev.key !== 'Delete' || !selectedEdge.value) return;
           ev.preventDefault();
           removeSelectedEdge();
         }
@@ -685,6 +690,15 @@
         function openImport() {
           gedcomText.value = '';
           showImport.value = true;
+        }
+
+        async function deleteAll() {
+          const ok = window.confirm('Delete all nodes and edges?');
+          if (!ok) return;
+          await FrontendApp.clearDatabase();
+          nodes.value = [];
+          edges.value = [];
+          try { localStorage.removeItem(TEMP_KEY); } catch (e) { /* ignore */ }
         }
 
         async function processImport() {
@@ -1218,6 +1232,7 @@
         downloadPng,
         downloadSvg,
         toggleSnap,
+        deleteAll,
         snapToGrid,
         horizontalGridSize,
         verticalGridSize,
@@ -1283,6 +1298,9 @@
               <svg viewBox="0 0 24 24">
                 <path d="M3 3h18v18H3V3m2 2v14h14V5H5Z" />
               </svg>
+            </button>
+            <button class="icon-button" @click="deleteAll" title="Delete All" style="border-color:#dc3545;color:#dc3545;">
+              <svg viewBox="0 0 24 24"><path d="M6 18L18 6M6 6l12 12" stroke-width="2" fill="none"/></svg>
             </button>
           </div>
           <VueFlow


### PR DESCRIPTION
## Summary
- allow clearing database via `clearDatabase`
- add Cmd/Ctrl+Shift+A shortcut to select all nodes
- add red toolbar button to delete all nodes/edges

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f2499091c833085cbdc94fa36d5e9