### PR TITLE
Fix multi-selection overlay visibility

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1304,7 +1304,6 @@
             :snap-to-grid="snapToGrid"
             :snap-grid="[horizontalGridSize, verticalGridSize]"
             selection-key-code="Shift"
-            multi-selection-key-code="Shift"
           >
             <template #node-person="{ data }">
               <div class="person-node" :class="{ 'highlight-node': data.highlight, 'faded-node': selected && !data.highlight }" :style="{ borderColor: data.gender === 'female' ? '#f8c' : (data.gender === 'male' ? '#88f' : '#ccc') }">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,6 +113,10 @@
     .faded-edge .vue-flow__edge-path {
       opacity: 0.3;
     }
+    .vue-flow__selection {
+      border: 1px dashed #3b82f6;
+      background: rgba(59, 130, 246, 0.1);
+    }
     .vue-flow__nodesselection-rect {
       border: 1px dashed #3b82f6;
       background: rgba(59, 130, 246, 0.1);


### PR DESCRIPTION
## Summary
- show drag selection box during multi-select
- remove multi-selection key override so deselection works

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f258011f08330a823f1116446fb55