### PR TITLE
Enable snap grid by default and hide mass delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ used for both the Node.js server and the Nginx proxy configuration. The front-en
 
 You can also tweak how tightly related nodes are drawn together by setting
 `RELATIVE_ATTRACTION` (0 = loose layout, 1 = very compact). It defaults to `0.5`.
+The bulk delete button is hidden by default. Set `SHOW_DELETE_ALL_BUTTON=true`
+if you want to display it in the toolbar.
 
 ### Running with Prebuilt Images
 

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -33,6 +33,7 @@ services:
     environment:
       BACKEND_PORT: ${BACKEND_PORT:-3009}
       RELATIVE_ATTRACTION: ${RELATIVE_ATTRACTION:-0.5}
+      SHOW_DELETE_ALL_BUTTON: ${SHOW_DELETE_ALL_BUTTON:-false}
     ports:
       - '${FRONTEND_PORT:-8080}:80'
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     environment:
       BACKEND_PORT: ${BACKEND_PORT:-3009}
       RELATIVE_ATTRACTION: ${RELATIVE_ATTRACTION:-0.5}
+      SHOW_DELETE_ALL_BUTTON: ${SHOW_DELETE_ALL_BUTTON:-false}
     ports:
       - '8080:80'
     depends_on:

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 # Substitute BACKEND_PORT env var into nginx config
-envsubst '$BACKEND_PORT $RELATIVE_ATTRACTION' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '$BACKEND_PORT $RELATIVE_ATTRACTION $SHOW_DELETE_ALL_BUTTON' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 # Substitute relative attraction into client config
 if [ -f /usr/share/nginx/html/src/config.js ]; then
-  envsubst '$RELATIVE_ATTRACTION' < /usr/share/nginx/html/src/config.js > /usr/share/nginx/html/src/config.js.tmp \
+  envsubst '$RELATIVE_ATTRACTION $SHOW_DELETE_ALL_BUTTON' < /usr/share/nginx/html/src/config.js > /usr/share/nginx/html/src/config.js.tmp \
     && mv /usr/share/nginx/html/src/config.js.tmp /usr/share/nginx/html/src/config.js
 fi
 exec nginx -g 'daemon off;'

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -51,6 +51,8 @@
             (typeof AppConfig.relativeAttraction !== 'undefined'
               ? parseFloat(AppConfig.relativeAttraction)
               : null)) || 0.5;
+        const showDeleteAllButton =
+          !!(window.AppConfig && AppConfig.showDeleteAllButton);
         const selected = ref(null);
         const showModal = ref(false);
         const contextMenuVisible = ref(false);
@@ -444,6 +446,7 @@
           await load();
           fitView();
           snapGrid.value = [horizontalGridSize, verticalGridSize];
+          snapToGrid.value = true;
           window.addEventListener('keydown', handleKeydown);
           window.addEventListener('keyup', handleKeyup);
         });
@@ -1377,6 +1380,7 @@
         filterActive,
         gotoPerson,
         personName,
+        showDeleteAllButton,
       };
       },
       template: `
@@ -1429,7 +1433,7 @@
                 <path d="M3 3h18v18H3V3m2 2v14h14V5H5Z" />
               </svg>
             </button>
-            <button class="icon-button" @click="deleteAll" title="Delete All" style="border-color:#dc3545;color:#dc3545;">
+            <button v-if="showDeleteAllButton" class="icon-button" @click="deleteAll" title="Delete All" style="border-color:#dc3545;color:#dc3545;">
               <svg viewBox="0 0 24 24"><path d="M6 18L18 6M6 6l12 12" stroke-width="2" fill="none"/></svg>
             </button>
           </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -208,6 +208,7 @@
     }
     .icon-button.active {
       border-color: #00B8D9;
+      box-shadow: 0 0 5px #00B8D9;
     }
     .icon-button svg {
       width: 16px;

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -13,5 +13,6 @@
     // how strongly relatives attract each other horizontally
     // 0 = very loose layout, 1 = compact layout
     relativeAttraction: parseFloat('${RELATIVE_ATTRACTION}') || 0.5,
+    showDeleteAllButton: '${SHOW_DELETE_ALL_BUTTON}' === 'true',
   };
 });


### PR DESCRIPTION
## Summary
- set snap-to-grid active when the app mounts
- highlight active toolbar buttons with a blue glow
- allow showing the delete-all button via `SHOW_DELETE_ALL_BUTTON` env var
- hide the delete-all button by default and document the env var

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fc6b1e4348330984e43e4bd685929