### PR TITLE
Improve search icon and grid behavior

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -53,6 +53,7 @@
           removeSelectedNodes,
           snapToGrid,
           snapGrid,
+          viewport,
         } = useVueFlow();
         const horizontalGridSize =
           (window.AppConfig &&
@@ -62,6 +63,15 @@
           (window.AppConfig &&
             (AppConfig.verticalGridSize || AppConfig.gridSize)) ||
           30;
+        const baseGridSize =
+          (horizontalGridSize + verticalGridSize) / 2;
+
+        function updateGridSize(zoom) {
+          const el = document.getElementById('flow-app');
+          if (!el) return;
+          const size = Math.max(8, baseGridSize / zoom);
+          el.style.backgroundSize = `${size}px ${size}px`;
+        }
         const relativeAttraction =
           (window.AppConfig &&
             (typeof AppConfig.relativeAttraction !== 'undefined'
@@ -463,6 +473,14 @@
           fitView();
           snapGrid.value = [horizontalGridSize, verticalGridSize];
           snapToGrid.value = true;
+          updateGridSize(viewport.value.zoom || 1);
+          watch(
+            viewport,
+            (v) => {
+              updateGridSize(v.zoom);
+            },
+            { deep: true }
+          );
           window.addEventListener('keydown', handleKeydown);
           window.addEventListener('keyup', handleKeyup);
         });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -194,18 +194,18 @@
       border-radius: 4px;
       cursor: pointer;
       transition: background-color 0.2s ease, border-color 0.2s ease;
-      border: 2px solid;
+      border: 1px solid;
       padding: 0;
       color: inherit;
     }
     body.bright-theme .icon-button {
       background-color: #ffffff;
-      border-color: #555555;
+      border-color: #666666;
       color: #555555;
     }
     body.dark-theme .icon-button {
-      background-color: transparent;
-      border-color: #cccccc;
+      background-color: #2a2a2a;
+      border-color: #888888;
       color: #ffffff;
     }
     .icon-button:hover {
@@ -350,8 +350,10 @@
     </div>
         <div id="flow-app" style="touch-action: none; overflow: hidden;">
           <div id="multiIndicator">Multi-select</div>
-          <button id="searchTrigger" class="btn btn-link" style="position:absolute;top:10px;right:10px;z-index:30;">
-            <span class="material-icons">search</span>
+          <button id="searchTrigger" class="icon-button" style="position:absolute;top:10px;right:10px;z-index:30;">
+            <svg viewBox="0 0 24 24">
+              <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zM10.5 14a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9z"/>
+            </svg>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ensure search button uses inline SVG icon
- adjust icon-button styling and lighten backgrounds
- watch canvas zoom and resize grid dynamically

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685019a68f0c83308d5fe555503e8505