### PR TITLE
Add basic i18n with German translations

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -261,9 +261,15 @@
     <header id="top-bar" class="py-2 px-3">
       <div class="d-flex justify-content-between align-items-center">
         <h1 class="h4 mb-0 brand-title">Tree of Life</h1>
-        <div id="themeToggleContainer" class="custom-control custom-switch mb-0">
-          <input type="checkbox" class="custom-control-input" id="themeToggle">
-          <label id="themeIcon" for="themeToggle" class="custom-control-label">&#9728;</label>
+        <div class="d-flex align-items-center">
+          <div id="themeToggleContainer" class="custom-control custom-switch mb-0 mr-2">
+            <input type="checkbox" class="custom-control-input" id="themeToggle">
+            <label id="themeIcon" for="themeToggle" class="custom-control-label">&#9728;</label>
+          </div>
+          <select id="langSelect" class="custom-select custom-select-sm" style="width:auto;">
+            <option value="EN">EN</option>
+            <option value="DE">DE</option>
+          </select>
         </div>
       </div>
     </header>
@@ -271,60 +277,60 @@
       <div id="app">
         <div id="menu">
       <div v-if="selectedPerson" class="edit-section">
-        <h2>Edit Person</h2>
+        <h2 data-i18n="editPerson">Edit Person</h2>
         <div class="form-row">
           <div class="col">
-            <label>Call Name</label>
-            <input class="form-control mb-2" v-model="selectedPerson.callName" placeholder="Call Name">
+            <label data-i18n="callName">Call Name</label>
+            <input class="form-control mb-2" v-model="selectedPerson.callName" placeholder="Call Name" data-i18n-placeholder="callName">
           </div>
           <div class="col">
-            <label>First Name</label>
-            <input class="form-control mb-2" v-model="selectedPerson.firstName" placeholder="First Name">
+            <label data-i18n="firstName">First Name</label>
+            <input class="form-control mb-2" v-model="selectedPerson.firstName" placeholder="First Name" data-i18n-placeholder="firstName">
           </div>
           <div class="col">
-            <label>Last Name</label>
-            <input class="form-control mb-2" v-model="selectedPerson.lastName" placeholder="Last Name">
+            <label data-i18n="lastName">Last Name</label>
+            <input class="form-control mb-2" v-model="selectedPerson.lastName" placeholder="Last Name" data-i18n-placeholder="lastName">
           </div>
         </div>
         <div class="form-row">
           <div class="col">
-            <label>Date of Birth</label>
-            <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfBirth" placeholder="DoB">
+            <label data-i18n="dateOfBirth">Date of Birth</label>
+            <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfBirth" placeholder="DoB" data-i18n-placeholder="dateOfBirth">
           </div>
           <div class="col">
-            <label>Date of Death</label>
-            <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfDeath" placeholder="DoD">
+            <label data-i18n="dateOfDeath">Date of Death</label>
+            <input class="form-control mb-2" type="date" v-model="selectedPerson.dateOfDeath" placeholder="DoD" data-i18n-placeholder="dateOfDeath">
           </div>
         </div>
         <div class="form-row">
           <div class="col">
-            <label>Place of Birth</label>
-            <input class="form-control mb-2" v-model="selectedPerson.placeOfBirth" placeholder="Place of Birth">
+            <label data-i18n="placeOfBirth">Place of Birth</label>
+            <input class="form-control mb-2" v-model="selectedPerson.placeOfBirth" placeholder="Place of Birth" data-i18n-placeholder="placeOfBirth">
           </div>
           <div class="col">
-            <label>Maiden Name</label>
-            <input class="form-control mb-2" v-model="selectedPerson.maidenName" placeholder="Maiden Name">
+            <label data-i18n="maidenName">Maiden Name</label>
+            <input class="form-control mb-2" v-model="selectedPerson.maidenName" placeholder="Maiden Name" data-i18n-placeholder="maidenName">
           </div>
         </div>
         <button class="btn btn-link p-0 mb-2" type="button" data-toggle="collapse" data-target="#editDetails">More Details</button>
         <div id="editDetails" class="collapse">
-          <label>Father</label>
+          <label data-i18n="father">Father</label>
           <select class="form-control mb-2" v-model="selectedPerson.fatherId">
-            <option value="">Father</option>
+            <option value="" data-i18n="father">Father</option>
             <option v-for="p in availableParentOptions" :value="p.id">{{ p.callName ? p.callName + ' (' + p.firstName + ')' : p.firstName }} {{ p.lastName }}</option>
           </select>
-          <label>Mother</label>
+          <label data-i18n="mother">Mother</label>
           <select class="form-control mb-2" v-model="selectedPerson.motherId">
-            <option value="">Mother</option>
+            <option value="" data-i18n="mother">Mother</option>
             <option v-for="p in availableParentOptions" :value="p.id">{{ p.callName ? p.callName + ' (' + p.firstName + ')' : p.firstName }} {{ p.lastName }}</option>
           </select>
-          <label>Notes</label>
-          <textarea class="form-control mb-2" v-model="selectedPerson.notes" placeholder="Notes"></textarea>
+          <label data-i18n="notes">Notes</label>
+          <textarea class="form-control mb-2" v-model="selectedPerson.notes" placeholder="Notes" data-i18n-placeholder="notes"></textarea>
         </div>
-        <button class="btn btn-success mr-2" @click="savePerson">Save</button>
-        <button class="btn btn-danger" @click="deleteSelected">Delete</button>
+        <button class="btn btn-success mr-2" @click="savePerson" data-i18n="save">Save</button>
+        <button class="btn btn-danger" @click="deleteSelected" data-i18n="delete">Delete</button>
         <div v-if="spouses.length" class="card">
-          <h3>Spouses</h3>
+          <h3 data-i18n="spouses">Spouses</h3>
           <ul>
             <li v-for="s in spouses">
               {{ s.spouse.callName ? s.spouse.callName + ' (' + s.spouse.firstName + ')' : s.spouse.firstName }} {{ s.spouse.lastName }}
@@ -338,7 +344,7 @@
           </ul>
         </div>
         <div v-if="childrenOfSelected.length" class="card">
-          <h3>Children</h3>
+          <h3 data-i18n="children">Children</h3>
           <ul>
             <li v-for="c in childrenOfSelected" :key="c.id">
               {{ c.callName ? c.callName + ' (' + c.firstName + ')' : c.firstName }} {{ c.lastName }}
@@ -349,13 +355,14 @@
       </div>
     </div>
         <div id="flow-app" style="touch-action: none; overflow: hidden;">
-          <div id="multiIndicator">Multi-select</div>
+          <div id="multiIndicator" data-i18n="multiSelect">Multi-select</div>
         </div>
       </div>
     </div>
     <footer id="footer" class="text-center py-2">&copy; BlauCity 2025</footer>
   </div>
   <script src="assets/js/argon-design-system.min.js"></script>
+  <script src="src/i18n.js"></script>
   <script src="app.js"></script>
   <script src="src/utils/exportSvg.js"></script>
   <script src="src/utils/assignGenerations.js"></script>
@@ -369,6 +376,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       const toggle = document.getElementById('themeToggle');
       const icon = document.getElementById('themeIcon');
+      const langSelect = document.getElementById('langSelect');
       function updateTheme() {
         document.body.classList.toggle('dark-theme', toggle.checked);
         document.body.classList.toggle('bright-theme', !toggle.checked);
@@ -381,6 +389,8 @@
       if (window.SearchApp) {
         SearchApp.init();
       }
+      langSelect.addEventListener('change', () => I18n.setLang(langSelect.value));
+      I18n.load(langSelect.value).then(() => I18n.updateDom());
     });
   </script>
 </body>

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,0 +1,35 @@
+(function (global) {
+  const translations = {};
+  let current = 'EN';
+
+  async function load(lang) {
+    if (!translations[lang]) {
+      const res = await fetch(`src/lang/${lang.toLowerCase()}.json`);
+      translations[lang] = await res.json();
+    }
+  }
+
+  function t(key) {
+    return (translations[current] && translations[current][key]) ||
+           (translations.EN && translations.EN[key]) || key;
+  }
+
+  async function setLang(lang) {
+    current = lang;
+    await load(lang);
+    updateDom();
+  }
+
+  function updateDom() {
+    document.querySelectorAll('[data-i18n]').forEach((el) => {
+      const k = el.getAttribute('data-i18n');
+      el.textContent = t(k);
+    });
+    document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
+      const k = el.getAttribute('data-i18n-placeholder');
+      el.setAttribute('placeholder', t(k));
+    });
+  }
+
+  global.I18n = { t, setLang, getLang: () => current, updateDom, load };
+})(this);

--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -1,0 +1,18 @@
+{
+  "editPerson": "Person bearbeiten",
+  "callName": "Rufname",
+  "firstName": "Vorname",
+  "lastName": "Nachname",
+  "dateOfBirth": "Geburtsdatum",
+  "dateOfDeath": "Sterbedatum",
+  "placeOfBirth": "Geburtsort",
+  "maidenName": "Geburtsname",
+  "father": "Vater",
+  "mother": "Mutter",
+  "notes": "Notizen",
+  "save": "Speichern",
+  "delete": "Löschen",
+  "spouses": "Ehepartner",
+  "children": "Kinder",
+  "multiSelect": "Mehrfachauswahl"
+}

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -1,0 +1,18 @@
+{
+  "editPerson": "Edit Person",
+  "callName": "Call Name",
+  "firstName": "First Name",
+  "lastName": "Last Name",
+  "dateOfBirth": "Date of Birth",
+  "dateOfDeath": "Date of Death",
+  "placeOfBirth": "Place of Birth",
+  "maidenName": "Maiden Name",
+  "father": "Father",
+  "mother": "Mother",
+  "notes": "Notes",
+  "save": "Save",
+  "delete": "Delete",
+  "spouses": "Spouses",
+  "children": "Children",
+  "multiSelect": "Multi-select"
+}


### PR DESCRIPTION
## Summary
- add simple i18n helper and German translation file
- hook i18n into frontend and expose EN/DE selector

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850773e20ec833083ff61841970c26e