### PR TITLE
Add language icon to header

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -261,17 +261,18 @@
     <header id="top-bar" class="py-2 px-3">
       <div class="d-flex justify-content-between align-items-center">
         <h1 class="h4 mb-0 brand-title">Tree of Life</h1>
-        <div class="d-flex align-items-center">
-          <div id="themeToggleContainer" class="custom-control custom-switch mb-0 mr-2">
-            <input type="checkbox" class="custom-control-input" id="themeToggle">
-            <label id="themeIcon" for="themeToggle" class="custom-control-label">&#9728;</label>
+          <div class="d-flex align-items-center">
+            <div id="themeToggleContainer" class="custom-control custom-switch mb-0 mr-2">
+              <input type="checkbox" class="custom-control-input" id="themeToggle">
+              <label id="themeIcon" for="themeToggle" class="custom-control-label">&#9728;</label>
+            </div>
+            <span id="langIcon" class="material-icons mr-1">language</span>
+            <select id="langSelect" class="custom-select custom-select-sm" style="width:auto;">
+              <option value="EN">EN</option>
+              <option value="DE">DE</option>
+            </select>
           </div>
-          <select id="langSelect" class="custom-select custom-select-sm" style="width:auto;">
-            <option value="EN">EN</option>
-            <option value="DE">DE</option>
-          </select>
         </div>
-      </div>
     </header>
     <div id="main-content">
       <div id="app">


### PR DESCRIPTION
## Summary
- show a language icon before the language selector

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68507b0a3d6c83308c0900eed31b0356