### PR TITLE
Fix duplicate death date field

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1746,10 +1746,6 @@
                         <label class="custom-control-label" for="birthApproxSwitch">Approx</label>
                       </div>
                     </div>
-                    <div class="col d-flex align-items-center mb-2">
-                      <label class="mr-2 mb-0" style="width: 90px;">Date of Death</label>
-                      <input class="form-control flex-fill" v-model="selected.dateOfDeath" type="date" title="Death date" />
-                    </div>
                   </div>
                   <div class="form-row">
                     <div class="col d-flex align-items-center mb-2">


### PR DESCRIPTION
## Summary
- remove the extra Date of Death input from the edit modal

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68507d498ac08330bc4274602c82de20