### PR TITLE
Show lifespans in search overlay

### DIFF
--- a/frontend/search.js
+++ b/frontend/search.js
@@ -87,7 +87,21 @@
     results.forEach(({ item }) => {
       const li = document.createElement('li');
       li.className = 'list-group-item list-group-item-action';
-      li.textContent = `${item.firstName} ${item.lastName}`;
+
+      const nameDiv = document.createElement('div');
+      nameDiv.textContent = `${item.firstName} ${item.lastName}`;
+      li.appendChild(nameDiv);
+
+      const born = item.dateOfBirth || item.birthApprox || '';
+      const died = item.dateOfDeath || item.deathApprox || '';
+      const life = [born, died].filter(Boolean).join(' - ');
+      if (life) {
+        const small = document.createElement('div');
+        small.className = 'small text-muted';
+        small.textContent = life;
+        li.appendChild(small);
+      }
+
       li.dataset.id = item.id;
       li.addEventListener('click', () => {
         if (root.FlowApp && typeof root.FlowApp.focusNode === 'function') {

--- a/frontend/test/search.test.js
+++ b/frontend/test/search.test.js
@@ -7,8 +7,20 @@ describe('SearchApp', () => {
     jest.resetModules();
     global.fetch = jest.fn().mockResolvedValue({
       json: () => [
-        { id: 1, firstName: 'John', lastName: 'Doe' },
-        { id: 2, firstName: 'Jane', lastName: 'Smith' },
+        {
+          id: 1,
+          firstName: 'John',
+          lastName: 'Doe',
+          dateOfBirth: '1900-01-01',
+          dateOfDeath: '1980-01-01',
+        },
+        {
+          id: 2,
+          firstName: 'Jane',
+          lastName: 'Smith',
+          dateOfBirth: '1905-05-10',
+          dateOfDeath: '1990-05-10',
+        },
       ],
     });
     global.Fuse = class {
@@ -36,6 +48,16 @@ describe('SearchApp', () => {
     const results = overlay.querySelectorAll('li');
     expect(results.length).toBe(1);
     expect(results[0].textContent).toContain('Jane Smith');
+  });
+
+  test('displays birth and death dates when available', () => {
+    const overlay = document.getElementById('search-overlay');
+    const input = overlay.querySelector('#search-input');
+    input.value = 'John';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    const result = overlay.querySelector('li');
+    expect(result.innerHTML).toContain('1900-01-01');
+    expect(result.innerHTML).toContain('1980-01-01');
   });
 
   test('show and hide control visibility', () => {


### PR DESCRIPTION
## Summary
- show DoB-DoD underneath names in search results
- test that search overlay displays life dates

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850fe69534c83309d8b7c73f9b42764