### PR TITLE
Fix i18n for dynamic modals

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -689,6 +689,18 @@
           if (ind) ind.style.display = val ? 'block' : 'none';
         });
 
+        function refreshI18n() {
+          if (I18n && typeof I18n.updateDom === 'function') {
+            nextTick(() => I18n.updateDom());
+          }
+        }
+
+        watch(showModal, refreshI18n);
+        watch(editing, refreshI18n);
+        watch(showImport, (v) => v && refreshI18n());
+        watch(showFilter, (v) => v && refreshI18n());
+        watch(showConflict, (v) => v && refreshI18n());
+
         function applyFilters() {
           const f = filters.value;
           filterActive.value =


### PR DESCRIPTION
## Summary
- ensure newly shown modals run translations

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685116a7ef64833083704bc548710923