### PR TITLE
Implement persistent theme and language settings

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -395,21 +395,35 @@
   <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      const THEME_KEY = 'preferredTheme';
       const toggle = document.getElementById('themeToggle');
       const icon = document.getElementById('themeIcon');
       const langSelect = document.getElementById('langSelect');
+
+      const savedTheme = (() => {
+        try { return localStorage.getItem(THEME_KEY); } catch (e) { return null; }
+      })();
+      if (savedTheme) toggle.checked = savedTheme === 'dark';
+
+      const savedLang = I18n.getLang();
+      langSelect.value = savedLang;
+
       function updateTheme() {
         document.body.classList.toggle('dark-theme', toggle.checked);
         document.body.classList.toggle('bright-theme', !toggle.checked);
         icon.textContent = toggle.checked ? '\u263D' : '\u2600';
+        try { localStorage.setItem(THEME_KEY, toggle.checked ? 'dark' : 'light'); } catch (e) { /* ignore */ }
       }
+
       toggle.addEventListener('change', updateTheme);
       updateTheme();
+
       FrontendApp.mountApp();
       FlowApp.mount();
       if (window.SearchApp) {
         SearchApp.init();
       }
+
       langSelect.addEventListener('change', () => I18n.setLang(langSelect.value));
       I18n.load(langSelect.value).then(() => I18n.updateDom());
     });

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,6 +1,13 @@
 (function (global) {
   const translations = {};
+  const STORAGE_KEY = 'preferredLang';
   let current = 'EN';
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) current = saved;
+  } catch (e) {
+    /* ignore */
+  }
 
   async function load(lang) {
     if (!translations[lang]) {
@@ -16,6 +23,11 @@
 
   async function setLang(lang) {
     current = lang;
+    try {
+      localStorage.setItem(STORAGE_KEY, lang);
+    } catch (e) {
+      /* ignore */
+    }
     await load(lang);
     updateDom();
   }


### PR DESCRIPTION
## Summary
- remember user's theme and language choice in localStorage
- restore saved preferences when loading the page

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68512419d6b083308952ab2df646b288