### PR TITLE
Add GeoNames location validation

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+GEONAMES_USER=mytestuser

--- a/backend/src/cache.js
+++ b/backend/src/cache.js
@@ -1,0 +1,47 @@
+let client = null;
+let connected = false;
+try {
+  const redis = require('redis');
+  client = redis.createClient({ url: process.env.REDIS_URL });
+  client.on('error', () => {});
+  client.connect().then(() => { connected = true; }).catch(() => {});
+} catch (e) {
+  client = null;
+}
+
+const memory = new Map();
+
+function now() { return Date.now(); }
+
+async function get(key) {
+  if (client && connected) {
+    try {
+      const v = await client.get(key);
+      return v ? JSON.parse(v) : null;
+    } catch (e) {
+      /* ignore */
+    }
+  }
+  const entry = memory.get(key);
+  if (!entry) return null;
+  if (entry.expire < now()) {
+    memory.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+async function set(key, value, ttl) {
+  const str = JSON.stringify(value);
+  if (client && connected) {
+    try {
+      await client.setEx(key, ttl, str);
+      return;
+    } catch (e) {
+      /* ignore */
+    }
+  }
+  memory.set(key, { value, expire: now() + ttl * 1000 });
+}
+
+module.exports = { get, set };

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -91,4 +91,18 @@ describe('People API', () => {
     const layoutRes = await request(app).get('/api/layout');
     expect(layoutRes.body.nodes[0].id).toBe(1);
   });
+
+  test('place suggestions route returns data', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        geonames: [
+          { geonameId: 1, name: 'Test', adminName1: 'X', countryCode: 'US', lat: '0', lng: '0', score: 1, fcode: 'PPL' },
+        ],
+      }),
+    });
+    const res = await request(app).get('/places/suggest?q=Test');
+    expect(res.statusCode).toBe(200);
+    expect(res.body[0].name).toBe('Test');
+  });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,15 @@ services:
       DB_PASSWORD: postgres
       DB_HOST: db
       PORT: ${BACKEND_PORT:-3009}
+      GEONAMES_USER: ${GEONAMES_USER}
+      REDIS_URL: redis://cache:6379
     ports:
       - '${BACKEND_PORT:-3009}:${BACKEND_PORT:-3009}'
     depends_on:
       db:
         condition: service_healthy
+      cache:
+        condition: service_started
     restart: unless-stopped
   frontend:
     build: ./frontend
@@ -38,6 +42,10 @@ services:
       - '8080:80'
     depends_on:
       - backend
+    restart: unless-stopped
+  cache:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
     restart: unless-stopped
 volumes:
   db-data:

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -13,4 +13,10 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
   }
+
+  location /places/ {
+    proxy_pass http://backend:${BACKEND_PORT};
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+  }
 }

--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -63,5 +63,6 @@
   "deleteAll": "Alle l\u00f6schen",
   "search": "Suche",
   "copyGedcom": "GEDCOM kopieren",
-  "avatar": "Avatar"
+  "avatar": "Avatar",
+  "useExactly": "Eingabe verwenden"
 }

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -63,5 +63,6 @@
   "deleteAll": "Delete All",
   "search": "Search",
   "copyGedcom": "Copy GEDCOM",
-  "avatar": "Avatar"
+  "avatar": "Avatar",
+  "useExactly": "Use Exactly"
 }


### PR DESCRIPTION
## Summary
- integrate GeoNames suggestions into backend
- add Redis cache helper and new `/places/suggest` endpoint
- validate place of birth when saving people
- provide Redis service and GeoNames user in docker-compose
- add place suggestion dropdown to person editor
- update German and English translations

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851a89c523483308fd75e9ae237cd68