### PR TITLE
Fix minor UI issues and prevent duplicate listeners

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -704,6 +704,9 @@
         }
 
         function useTypedPlace() {
+          if (selected.value) {
+            selected.value.placeOfBirth = (selected.value.placeOfBirth || '').trim();
+          }
           placeFocus.value = false;
         }
 
@@ -1507,15 +1510,16 @@
         }
       }
 
-       function openContextMenu(ev) {
-         const point = ev.touches ? ev.touches[0] : ev;
-         const rect = document
-           .getElementById('flow-app')
-           .getBoundingClientRect();
-         contextX.value = point.clientX - rect.left;
-         contextY.value = point.clientY - rect.top;
-         contextMenuVisible.value = true;
-       }
+      function openContextMenu(ev) {
+        clearTimeout(longPressTimer);
+        const point = ev.touches ? ev.touches[0] : ev;
+        const rect = document
+          .getElementById('flow-app')
+          .getBoundingClientRect();
+        contextX.value = point.clientX - rect.left;
+        contextY.value = point.clientY - rect.top;
+        contextMenuVisible.value = true;
+      }
 
        function handleContextMenu(ev) {
          ev.preventDefault();

--- a/frontend/search.js
+++ b/frontend/search.js
@@ -15,8 +15,11 @@
         ? self
         : (typeof global !== 'undefined' ? global : {})));
   const overlayId = 'search-overlay';
+  let initialized = false;
 
   async function init() {
+    if (initialized) return;
+    initialized = true;
     try {
       const res = await fetch('/api/people');
       people = await res.json();
@@ -45,8 +48,11 @@
       document.body.appendChild(overlay);
     }
     const input = overlay.querySelector('#search-input');
-    input.addEventListener('input', updateResults);
-    input.addEventListener('keydown', handleInputKey);
+    if (!input.dataset.bound) {
+      input.addEventListener('input', updateResults);
+      input.addEventListener('keydown', handleInputKey);
+      input.dataset.bound = 'true';
+    }
   }
 
   function handleInputKey(e) {


### PR DESCRIPTION
## Summary
- avoid duplicate SearchApp initialization and event binding
- store typed place name when closing dropdown
- clear long press timer when opening context menu

## Testing
- `npm run lint`
- `npm test` (frontend)
- `npm run lint` (backend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_6851bf2ed91083308081aa03bcf13293