### PR TITLE
Add cache to deployment compose

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -22,11 +22,14 @@ services:
       DB_PASSWORD: postgres
       DB_HOST: db
       PORT: ${BACKEND_PORT:-3009}
+      REDIS_URL: redis://cache:6379
     ports:
       - '${BACKEND_PORT:-3009}:${BACKEND_PORT:-3009}'
     depends_on:
       db:
         condition: service_healthy
+      cache:
+        condition: service_started
     restart: unless-stopped
   frontend:
     image: ghcr.io/magsimal/blauclan-frontend:latest
@@ -38,6 +41,10 @@ services:
       - '${FRONTEND_PORT:-8080}:80'
     depends_on:
       - backend
+    restart: unless-stopped
+  cache:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
     restart: unless-stopped
 volumes:
   db-data:


### PR DESCRIPTION
## Summary
- include Redis cache service in `docker-compose.deploy.yml`
- point backend at the cache service

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851cf7a105c833090e0db2dc0ad0f25