### PR TITLE
Fix node deletion persistence

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -909,6 +909,18 @@
           }
         }
 
+        async function handleNodesChange(changes) {
+          const removed = (changes || []).filter((c) => c.type === 'remove');
+          for (const r of removed) {
+            if (!/^\d+$/.test(r.id)) continue;
+            try {
+              await FrontendApp.deletePerson(parseInt(r.id, 10));
+            } catch (e) {
+              console.error('Failed to delete person', r.id, e);
+            }
+          }
+        }
+
         async function deleteAll() {
           const ok = window.confirm('Delete all nodes and edges?');
           if (!ok) return;
@@ -1621,6 +1633,7 @@
         filters,
         filterActive,
         triggerSearch,
+        handleNodesChange,
         gotoPerson,
         personName,
         placeSuggestions,
@@ -1711,6 +1724,7 @@
             @touchstart="handleTouchStart"
             @touchend="handleTouchEnd"
             @touchcancel="handleTouchEnd"
+            @nodes-change="handleNodesChange"
             :fit-view-on-init="true"
             :min-zoom="0.1"
             :select-nodes-on-drag="true"


### PR DESCRIPTION
## Summary
- ensure node deletions via keyboard also remove people from the backend
- watch for VueFlow `nodes-change` events and call the existing delete API

## Testing
- `cd frontend && npm run lint && npm test`
- `cd backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851d03100788330b1efa8899c5b45e1