### PR TITLE
Improve marriage validation and tests

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -169,7 +169,33 @@ app.post('/api/people/:id/spouses', async (req, res) => {
     const id = parseInt(req.params.id, 10);
     if (Number.isNaN(id)) return res.status(400).json({ error: 'Invalid ID' });
     const spouseId = parseInt(req.body.spouseId, 10);
-    if (Number.isNaN(spouseId)) return res.status(400).json({ error: 'Invalid spouseId' });
+    if (Number.isNaN(spouseId)) {
+      return res.status(400).json({ error: 'Invalid spouseId' });
+    }
+    if (id === spouseId) {
+      return res.status(400).json({ error: 'Cannot marry self' });
+    }
+
+    const [person, spouse] = await Promise.all([
+      Person.findByPk(id),
+      Person.findByPk(spouseId),
+    ]);
+    if (!person || !spouse) {
+      return res.status(404).json({ error: 'Person not found' });
+    }
+
+    const existing = await Marriage.findOne({
+      where: {
+        [Op.or]: [
+          { personId: id, spouseId },
+          { personId: spouseId, spouseId: id },
+        ],
+      },
+    });
+    if (existing) {
+      return res.status(400).json({ error: 'Marriage already exists' });
+    }
+
     const marriage = await Marriage.create({
       personId: id,
       spouseId,

--- a/backend/src/models/marriage.js
+++ b/backend/src/models/marriage.js
@@ -10,7 +10,16 @@ module.exports = (sequelize) => {
       marriageApprox: DataTypes.STRING,
       placeOfMarriage: DataTypes.STRING,
     },
-    { sequelize, modelName: 'Marriage' }
+    {
+      sequelize,
+      modelName: 'Marriage',
+      indexes: [
+        {
+          unique: true,
+          fields: ['personId', 'spouseId'],
+        },
+      ],
+    }
   );
   return Marriage;
 };

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -69,6 +69,27 @@ describe('People API', () => {
     expect(getRes.body.birthApprox).toBe('ABT 1900');
   });
 
+  test('rejects invalid spouse relationships', async () => {
+    await sequelize.sync({ force: true });
+    await request(app).post('/api/people').send({ firstName: 'A', lastName: 'B' });
+    await request(app).post('/api/people').send({ firstName: 'C', lastName: 'D' });
+
+    const selfRes = await request(app)
+      .post('/api/people/1/spouses')
+      .send({ spouseId: 1 });
+    expect(selfRes.statusCode).toBe(400);
+
+    const first = await request(app)
+      .post('/api/people/1/spouses')
+      .send({ spouseId: 2 });
+    expect(first.statusCode).toBe(201);
+
+    const dupRes = await request(app)
+      .post('/api/people/2/spouses')
+      .send({ spouseId: 1 });
+    expect(dupRes.statusCode).toBe(400);
+  });
+
   test('exports and imports database', async () => {
     await sequelize.sync({ force: true });
     await request(app).post('/api/people').send({ firstName: 'A', lastName: 'B' });


### PR DESCRIPTION
## Summary
- enforce uniqueness on marriages with a composite index
- validate spouse creation to avoid duplicates and self-marriage
- test invalid spouse scenarios

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68532fa01cac8330aee8c52ba5b137eb