### PR TITLE
Fix stale geonames suggestions

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -677,14 +677,20 @@
           }
         });
 
+        let placeController = null;
         const fetchPlaces = debounce(async (val) => {
+          if (placeController) placeController.abort();
           if (!val) { placeSuggestions.value = []; return; }
+          placeController = new AbortController();
           const lang = I18nGlobal.getLang ? I18nGlobal.getLang().toLowerCase() : 'en';
           try {
-            const res = await fetch(`/places/suggest?q=${encodeURIComponent(val)}&lang=${lang}`);
+            const res = await fetch(
+              `/places/suggest?q=${encodeURIComponent(val)}&lang=${lang}`,
+              { signal: placeController.signal },
+            );
             placeSuggestions.value = res.ok ? await res.json() : [];
           } catch (e) {
-            placeSuggestions.value = [];
+            if (e.name !== 'AbortError') placeSuggestions.value = [];
           }
         }, 250);
 


### PR DESCRIPTION
## Summary
- cancel previous geonames fetch requests using AbortController in both Vue entry points

## Testing
- `cd frontend && npm run lint && npm test`
- `cd ../backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68532f679740833086bad868146f3d9a