### PR TITLE
Support GeoNames env in deploy compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ docker-compose -f docker-compose.deploy.yml up -d
 ```
 
 Replace `OWNER` in `docker-compose.deploy.yml` with your GitHub username or organisation.
+Ensure your `.env` file also defines `GEONAMES_USER` so the backend can access GeoNames.
 
 ### Running Backend Tests
 

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -22,6 +22,7 @@ services:
       DB_PASSWORD: postgres
       DB_HOST: db
       PORT: ${BACKEND_PORT:-3009}
+      GEONAMES_USER: ${GEONAMES_USER}
       REDIS_URL: redis://cache:6379
     ports:
       - '${BACKEND_PORT:-3009}:${BACKEND_PORT:-3009}'


### PR DESCRIPTION
## Summary
- add `GEONAMES_USER` variable to `docker-compose.deploy.yml`
- document using the variable when running with prebuilt images

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685338686f2c83308742dad6e72f3767