### PR TITLE
Log GEONAMES_USER at startup

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -63,6 +63,7 @@ async function geonamesSuggest(query, lang = 'en', cc = '') {
 }
 
 async function verifyGeonames() {
+  console.log(`GEONAMES_USER: ${process.env.GEONAMES_USER || '(not set)'}`);
   if (!process.env.GEONAMES_USER) {
     console.log('GeoNames disabled: GEONAMES_USER not set');
     geonamesEnabled = false;


### PR DESCRIPTION
## Summary
- log the value of `GEONAMES_USER` when verifying GeoNames

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685340b4d28483308bc00957992d7113