### PR TITLE
Improve GeoNames logging & quiet SQL logs

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -39,8 +39,9 @@ async function geonamesSuggest(query, lang = 'en', cc = '') {
   if (cc) url.searchParams.set('country', cc);
   url.searchParams.set('isNameRequired', 'true');
   try {
+    console.debug(`GeoNames request: ${url.toString()}`);
     const resp = await fetch(url);
-    if (!resp.ok) throw new Error('geonames error');
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const data = await resp.json();
     let res = Array.isArray(data.geonames) ? data.geonames : [];
     if (!/County|Province|District/i.test(q)) {
@@ -58,6 +59,7 @@ async function geonamesSuggest(query, lang = 'en', cc = '') {
     await cache.set(key, final, 86400);
     return final;
   } catch (e) {
+    console.warn(`GeoNames request failed for ${url.toString()}: ${e.message}`);
     return [];
   }
 }

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -2,11 +2,14 @@ const { Sequelize } = require('sequelize');
 const dialect = process.env.DB_DIALECT || 'postgres';
 const isSqlite = dialect === 'sqlite';
 
+const logging = process.env.SQL_DEBUG === 'true' ? (msg) => console.debug(msg) : false;
+
 const sequelize = new Sequelize(
   isSqlite
     ? {
         dialect: 'sqlite',
         storage: process.env.DB_STORAGE || 'database.sqlite',
+        logging,
       }
     : {
         database: process.env.DB_NAME || 'familytree',
@@ -14,6 +17,7 @@ const sequelize = new Sequelize(
         password: process.env.DB_PASSWORD || 'postgres',
         host: process.env.DB_HOST || 'localhost',
         dialect: 'postgres',
+        logging,
       }
 );
 


### PR DESCRIPTION
## Summary
- log outbound GeoNames requests and failures
- make Sequelize SQL logging optional via `SQL_DEBUG`

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68538cd22a988330a73634587e707b90