### PR TITLE
Fix POB suggestions visibility

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -181,7 +181,8 @@
           const idx = this.people.findIndex((p) => p.id === updated.id);
           if (idx !== -1) Object.assign(this.people[idx], updated);
         },
-        onPobInput(e) {
+       onPobInput(e) {
+          this.pobFocus = true;
           if (this.debouncedPob) this.debouncedPob(e.target.value);
         },
         hidePobDropdown() {
@@ -189,6 +190,7 @@
         },
         applyPob(s) {
           if (this.selectedPerson) this.selectedPerson.placeOfBirth = s.name;
+          this.pobSuggestions = [];
           this.pobFocus = false;
         },
         useTypedPob() {


### PR DESCRIPTION
## Summary
- keep place suggestions open while typing
- clear suggestions when applying a selection

## Testing
- `cd backend && npm run lint && npm test` *(fails: fetch failed)*
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853b8cac60c8330b1cee4fc4ac3267a