### PR TITLE
Fix dash handling in GeoNames lookup

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -25,7 +25,11 @@ let geonamesEnabled = true;
 
 async function geonamesSuggest(query, lang = 'en', cc = '') {
   if (!geonamesEnabled) return [];
-  const q = query.trim().replace(/\s+/g, ' ');
+  const q = query
+    .trim()
+    .replace(/[\u2013\u2014]/g, '-')
+    .replace(/\s*-\s*/g, '-')
+    .replace(/\s+/g, ' ');
   if (!q) return [];
   const hash = crypto.createHash('sha1').update(q + lang + cc).digest('hex');
   const key = `gn:${hash}`;

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -126,4 +126,15 @@ describe('People API', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body[0].name).toBe('Test');
   });
+
+  test('place suggestions normalize dash characters', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ geonames: [] }) });
+    global.fetch = fetchMock;
+    const res = await request(app)
+      .get('/places/suggest')
+      .query({ q: 'Foo\u2013Bar' });
+    expect(res.statusCode).toBe(200);
+    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0][0]).toContain('q=Foo-Bar');
+  });
 });


### PR DESCRIPTION
## Summary
- normalize different dash characters before GeoNames lookup
- test dash normalization when requesting place suggestions

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853c94384c0833097bbcb29314b6347