### PR TITLE
Fix GeoNames encoding

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -36,7 +36,8 @@ async function geonamesSuggest(query, lang = 'en', cc = '') {
   const cached = await cache.get(key);
   if (cached) return cached;
   // The GeoNames API only works over HTTP for free accounts
-  const url = `http://api.geonames.org/searchJSON?q=${encodeURIComponent(q)}`
+  const encoded = encodeURIComponent(q).replace(/-/g, '%2D');
+  const url = `http://api.geonames.org/searchJSON?q=${encoded}`
     + `&fuzzy=0.8&maxRows=10&username=${GEONAMES_USER}`
     + `&lang=${lang}`
     + (cc ? `&country=${cc}` : '')

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -135,6 +135,17 @@ describe('People API', () => {
       .query({ q: 'Foo\u2013Bar' });
     expect(res.statusCode).toBe(200);
     expect(fetchMock).toHaveBeenCalled();
-    expect(fetchMock.mock.calls[0][0]).toContain('q=Foo-Bar');
+    expect(fetchMock.mock.calls[0][0]).toContain('q=Foo%2DBar');
+  });
+
+  test('place suggestions encode umlauts correctly', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ geonames: [] }) });
+    global.fetch = fetchMock;
+    const res = await request(app)
+      .get('/places/suggest')
+      .query({ q: 'M\u00fcnchen' });
+    expect(res.statusCode).toBe(200);
+    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0][0]).toContain('q=M%C3%BCnchen');
   });
 });


### PR DESCRIPTION
## Summary
- encode dash as `%2D` when calling the GeoNames API
- add umlaut encoding test

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853f0dc1a788330a11e646fe6319079