### PR TITLE
Fix Vue context menu error

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1951,8 +1951,15 @@
             <li @click="menuAdd">Add New</li>
             <li @click="menuTidy">Tidy Up</li>
             <li @click="menuFit">Zoom to Fit</li>
-            <li v-if="getSelectedNodes.value.length === 1" @click="openRelatives" data-i18n="showRelatives">Show Relatives</li>
-            <li v-if="getSelectedNodes.value.length > 1" @click="copySelectedGedcom">Copy GEDCOM</li>
+            <li
+              v-if="getSelectedNodes && getSelectedNodes.value && getSelectedNodes.value.length === 1"
+              @click="openRelatives"
+              data-i18n="showRelatives"
+            >Show Relatives</li>
+            <li
+              v-if="getSelectedNodes && getSelectedNodes.value && getSelectedNodes.value.length > 1"
+              @click="copySelectedGedcom"
+            >Copy GEDCOM</li>
           </ul>
 
           <div v-if="showImport" class="modal">


### PR DESCRIPTION
## Summary
- avoid runtime error when checking selected node count in context menu

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854535bbce88330b3cc927158538ac0