### PR TITLE
Fix portainer deploy trigger

### DIFF
--- a/.github/workflows/portainer-redeploy.yml
+++ b/.github/workflows/portainer-redeploy.yml
@@ -1,11 +1,14 @@
 name: Trigger Portainer Deploy via n8n
 
 on:
-  push:
-    branches: [main, develop]
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 jobs:
   notify-n8n:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'develop') }}
     runs-on: ubuntu-latest
     container:
       image: curlimages/curl:latest
@@ -15,13 +18,14 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.N8N_WEBHOOK_URL }}
           WEBHOOK_SECRET: ${{ secrets.N8N_WEBHOOK_SECRET }}
+          REF: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [[ "${GITHUB_REF##*/}" == "main" ]]; then
+          if [[ "$REF" == "main" ]]; then
             STACK_ID=139
-          elif [[ "${GITHUB_REF##*/}" == "develop" ]]; then
+          elif [[ "$REF" == "develop" ]]; then
             STACK_ID=140
           else
-            echo "No action for branch ${GITHUB_REF##*/}"
+            echo "No action for branch $REF"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- trigger Portainer redeploy workflow from CI completion
- filter by successful runs on main or develop branches

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685454cdc7dc8330b286dd01e50795a4