### PR TITLE
Fix context menu when nodes selected

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1952,12 +1952,12 @@
             <li @click="menuTidy">Tidy Up</li>
             <li @click="menuFit">Zoom to Fit</li>
             <li
-              v-if="getSelectedNodes && getSelectedNodes.value && getSelectedNodes.value.length === 1"
+              v-if="getSelectedNodes && getSelectedNodes.value && getSelectedNodes.value.length > 0"
               @click="openRelatives"
               data-i18n="showRelatives"
             >Show Relatives</li>
             <li
-              v-if="getSelectedNodes && getSelectedNodes.value && getSelectedNodes.value.length > 1"
+              v-if="getSelectedNodes && getSelectedNodes.value && getSelectedNodes.value.length > 0"
               @click="copySelectedGedcom"
             >Copy GEDCOM</li>
           </ul>


### PR DESCRIPTION
## Summary
- show `Copy GEDCOM` and `Show Relatives` menu items whenever any node is selected

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685456b82a448330a5dcfaf4cb0248a8