### PR TITLE
Enhance PoB suggestions with caching and dedup

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -2205,7 +2205,7 @@
                       <label class="small" data-i18n="placeOfBirth">Place of Birth</label>
                       <input class="form-control" v-model="selected.placeOfBirth" placeholder="City or town" title="Place of birth" data-i18n-placeholder="placeOfBirth" @focus="placeFocus=true; onPlaceInput($event)" @blur="hidePlaceDropdown" @input="onPlaceInput" />
                       <ul v-if="placeFocus && placeSuggestions.length" class="list-group position-absolute" style="top:100%; left:0; right:0; z-index:1000; max-height:150px; overflow-y:auto;" @scroll="onPlaceScroll">
-                        <li v-for="s in visiblePlaceSuggestions()" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPlace(s)">{{ s.name }}<span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
+        <li v-for="s in visiblePlaceSuggestions()" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPlace(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
                         <li class="list-group-item list-group-item-action" @mousedown.prevent="useTypedPlace" data-i18n="useExactly">Use Exactly</li>
                       </ul>
                     </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -329,7 +329,7 @@
             <label data-i18n="placeOfBirth">Place of Birth</label>
             <input class="form-control mb-2" v-model="selectedPerson.placeOfBirth" placeholder="Place of Birth" data-i18n-placeholder="placeOfBirth" @focus="pobFocus=true; onPobInput($event)" @blur="hidePobDropdown" @input="onPobInput">
             <ul v-if="pobFocus && pobSuggestions.length" class="list-group position-absolute" style="top:100%; left:0; right:0; z-index:1000; max-height:150px; overflow-y:auto;" @scroll="onPobScroll">
-              <li v-for="s in visiblePobSuggestions" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPob(s)">{{ s.name }}<span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
+              <li v-for="s in visiblePobSuggestions" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPob(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
               <li class="list-group-item list-group-item-action" @mousedown.prevent="useTypedPob" data-i18n="useExactly">Use Exactly</li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- cache GeoNames postal lookups to reduce API traffic
- remove duplicate GeoNames results before returning suggestions
- test new deduplication logic

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685686335aa48330a90e8cbe0ae9b783