### PR TITLE
Store geoname reference for places of birth

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -14,7 +14,7 @@ app.get('/api/people', async (_req, res) => {
 
 function normalizeParentIds(data) {
   const updates = { ...data };
-  ['fatherId', 'motherId', 'birthApprox', 'deathApprox'].forEach((field) => {
+  ['fatherId', 'motherId', 'birthApprox', 'deathApprox', 'geonameId'].forEach((field) => {
     if (updates[field] === '') updates[field] = null;
   });
   return updates;

--- a/backend/src/models/person.js
+++ b/backend/src/models/person.js
@@ -14,6 +14,7 @@ module.exports = (sequelize) => {
       birthApprox: DataTypes.STRING,
       deathApprox: DataTypes.STRING,
       placeOfBirth: DataTypes.STRING,
+      geonameId: DataTypes.INTEGER,
       notes: DataTypes.TEXT,
       avatarUrl: DataTypes.STRING,
       gedcomId: DataTypes.STRING,

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -69,6 +69,16 @@ describe('People API', () => {
     expect(getRes.body.birthApprox).toBe('ABT 1900');
   });
 
+  test('stores geoname ID', async () => {
+    const res = await request(app)
+      .post('/api/people')
+      .send({ firstName: 'Geo', lastName: 'Test', geonameId: 42, placeOfBirth: 'Munich' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.geonameId).toBe(42);
+    const getRes = await request(app).get(`/api/people/${res.body.id}`);
+    expect(getRes.body.geonameId).toBe(42);
+  });
+
   test('rejects invalid spouse relationships', async () => {
     await sequelize.sync({ force: true });
     await request(app).post('/api/people').send({ firstName: 'A', lastName: 'B' });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -203,13 +203,17 @@
           setTimeout(() => { this.pobFocus = false; }, 150);
         },
         applyPob(s) {
-          if (this.selectedPerson) this.selectedPerson.placeOfBirth = s.name;
+          if (this.selectedPerson) {
+            this.selectedPerson.placeOfBirth = s.name;
+            this.selectedPerson.geonameId = s.geonameId;
+          }
           this.pobSuggestions = [];
           this.pobFocus = false;
         },
         useTypedPob() {
           if (this.selectedPerson) {
             this.selectedPerson.placeOfBirth = (this.selectedPerson.placeOfBirth || '').trim();
+            this.selectedPerson.geonameId = null;
           }
           this.pobFocus = false;
         },
@@ -232,6 +236,7 @@
             dateOfDeath: this.selectedPerson.dateOfDeath || null,
             deathApprox: this.selectedPerson.deathApprox || null,
             placeOfBirth: this.selectedPerson.placeOfBirth || '',
+            geonameId: this.selectedPerson.geonameId || null,
             fatherId: this.selectedPerson.fatherId || null,
             motherId: this.selectedPerson.motherId || null,
             notes: this.selectedPerson.notes || '',

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -786,7 +786,7 @@
             const payload = { ...selected.value };
             const spouseId = payload.spouseId;
             delete payload.spouseId;
-            ['maidenName', 'dateOfBirth', 'birthApprox', 'dateOfDeath', 'deathApprox', 'placeOfBirth', 'notes', 'fatherId', 'motherId'].forEach((f) => {
+            ['maidenName', 'dateOfBirth', 'birthApprox', 'dateOfDeath', 'deathApprox', 'placeOfBirth', 'geonameId', 'notes', 'fatherId', 'motherId'].forEach((f) => {
               if (payload[f] === '') payload[f] = null;
             });
             const updated = await FrontendApp.updatePerson(selected.value.id, payload);
@@ -862,6 +862,7 @@
         function useTypedPlace() {
           if (selected.value) {
             selected.value.placeOfBirth = (selected.value.placeOfBirth || '').trim();
+            selected.value.geonameId = null;
           }
           placeFocus.value = false;
         }
@@ -1361,7 +1362,7 @@
           const payload = { ...originalSelected };
           const spouseId = payload.spouseId;
           delete payload.spouseId;
-          ['maidenName', 'dateOfBirth', 'birthApprox', 'dateOfDeath', 'deathApprox', 'placeOfBirth', 'notes', 'fatherId', 'motherId'].forEach((f) => {
+          ['maidenName', 'dateOfBirth', 'birthApprox', 'dateOfDeath', 'deathApprox', 'placeOfBirth', 'geonameId', 'notes', 'fatherId', 'motherId'].forEach((f) => {
             if (payload[f] === '') payload[f] = null;
           });
           await FrontendApp.updatePerson(originalSelected.id, payload);
@@ -1571,6 +1572,7 @@
             dateOfDeath: selected.value.dateOfDeath || null,
             deathApprox: selected.value.deathApprox || null,
             placeOfBirth: selected.value.placeOfBirth || null,
+            geonameId: selected.value.geonameId || null,
             notes: selected.value.notes || null,
             gender: selected.value.gender,
             fatherId: selected.value.fatherId || null,
@@ -2107,7 +2109,9 @@
                       >{{ selected.dateOfDeath || selected.deathApprox }}</span
                     >
                   </p>
-                  <p v-if="selected.placeOfBirth"><strong data-i18n="placeOfBirthLabel">Place of Birth:</strong> {{ selected.placeOfBirth }}</p>
+                  <p v-if="selected.placeOfBirth"><strong data-i18n="placeOfBirthLabel">Place of Birth:</strong> {{ selected.placeOfBirth }}
+                    <span v-if="selected.geonameId" class="text-success" title="GeoNames match stored" data-i18n-title="geoStored">&#10003;</span>
+                  </p>
                   <p>
                     <strong data-i18n="fatherLabel">Father:</strong>
                     <template v-if="selected.fatherId">
@@ -2202,7 +2206,9 @@
                   </div>
                   <div class="form-row">
                     <div class="col mb-2 position-relative">
-                      <label class="small" data-i18n="placeOfBirth">Place of Birth</label>
+                      <label class="small" data-i18n="placeOfBirth">Place of Birth
+                        <span v-if="selected.geonameId" class="text-success" title="GeoNames match stored" data-i18n-title="geoStored">&#10003;</span>
+                      </label>
                       <input class="form-control" v-model="selected.placeOfBirth" placeholder="City or town" title="Place of birth" data-i18n-placeholder="placeOfBirth" @focus="placeFocus=true; onPlaceInput($event)" @blur="hidePlaceDropdown" @input="onPlaceInput" />
                       <ul v-if="placeFocus && placeSuggestions.length" class="list-group position-absolute" style="top:100%; left:0; right:0; z-index:1000; max-height:150px; overflow-y:auto;" @scroll="onPlaceScroll">
         <li v-for="s in visiblePlaceSuggestions()" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPlace(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -326,7 +326,9 @@
         </div>
         <div class="form-row">
           <div class="col position-relative">
-            <label data-i18n="placeOfBirth">Place of Birth</label>
+            <label data-i18n="placeOfBirth">Place of Birth
+              <span v-if="selectedPerson.geonameId" class="text-success" title="GeoNames match stored" data-i18n-title="geoStored">&#10003;</span>
+            </label>
             <input class="form-control mb-2" v-model="selectedPerson.placeOfBirth" placeholder="Place of Birth" data-i18n-placeholder="placeOfBirth" @focus="pobFocus=true; onPobInput($event)" @blur="hidePobDropdown" @input="onPobInput">
             <ul v-if="pobFocus && pobSuggestions.length" class="list-group position-absolute" style="top:100%; left:0; right:0; z-index:1000; max-height:150px; overflow-y:auto;" @scroll="onPobScroll">
               <li v-for="s in visiblePobSuggestions" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPob(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>

--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -65,6 +65,7 @@
   "copyGedcom": "GEDCOM kopieren",
   "avatar": "Avatar",
   "useExactly": "Eingabe verwenden",
+  "geoStored": "GeoNames-Ort gespeichert",
   "showRelatives": "Verwandte anzeigen",
   "relativeView": "Verwandtschaft",
   "ancestorsOnly": "Vorfahren",

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -65,6 +65,7 @@
   "copyGedcom": "Copy GEDCOM",
   "avatar": "Avatar",
   "useExactly": "Use Exactly",
+  "geoStored": "GeoNames place stored",
   "showRelatives": "Show Relatives",
   "relativeView": "Relatives View",
   "ancestorsOnly": "Ancestors",


### PR DESCRIPTION
## Summary
- add `geonameId` to `Person` model
- keep the GeoNames ID when creating and editing people
- show an indicator when a GeoNames place is stored
- translate tooltip label
- test persistence of the new field

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d0a5ce26c83308389516c38702ac7