### PR TITLE
Improve GeoNames fuzzy search

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -78,8 +78,12 @@ async function geonamesSuggest(query, lang = 'en', cc = '') {
   if (cached) return cached;
   // The GeoNames API only works over HTTP for free accounts
   const encoded = encodeURIComponent(q).replace(/-/g, '%2D');
-  const url = `http://api.geonames.org/searchJSON?q=${encoded}`
-    + `&fuzzy=0.8&maxRows=100&username=${GEONAMES_USER}`
+  const queryParam =
+    q.length < 4
+      ? `name_startsWith=${encoded}`
+      : `q=${encoded}&fuzzy=0.8`;
+  const url = `http://api.geonames.org/searchJSON?${queryParam}`
+    + `&maxRows=100&username=${GEONAMES_USER}`
     + `&lang=${lang}`
     + (cc ? `&country=${cc}` : '')
     + '&isNameRequired=true';

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -149,6 +149,7 @@ describe('People API', () => {
       });
     const res = await request(app).get('/places/suggest?q=Dup');
     expect(res.statusCode).toBe(200);
+    expect(global.fetch.mock.calls[0][0]).toContain('name_startsWith=Dup');
     expect(res.body[0].name).toBe('Test');
     expect(res.body[0].postalCode).toBe('12345');
   });
@@ -189,6 +190,7 @@ describe('People API', () => {
       });
     const res = await request(app).get('/places/suggest?q=Test');
     expect(res.statusCode).toBe(200);
+    expect(global.fetch.mock.calls[0][0]).toContain('q=Test');
     expect(res.body.length).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
- query GeoNames API with `name_startsWith` when query is short
- adjust backend tests for new behavior

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d0d7053388330a36f7f05e3a7295f