### PR TITLE
Improve node border aesthetics

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -65,12 +65,12 @@
     }
     body.dark-theme .person-node {
       background: #333;
-      border: 2px solid #555;
+      border: 1px solid #555;
       color: #eee;
     }
     body.bright-theme .person-node {
       background: #fff;
-      border: 2px solid #ddd;
+      border: 1px solid #ddd;
       color: #333;
     }
     .person-node:hover {

--- a/frontend/vue-flow-style.css
+++ b/frontend/vue-flow-style.css
@@ -139,7 +139,7 @@
 .vue-flow__node-default,
 .vue-flow__node-input,
 .vue-flow__node-output {
-  border-width: 1px;
+  border-width: 0.5px;
   border-style: solid;
   border-color: #bbb;
 }
@@ -154,7 +154,7 @@
   .vue-flow__node-output:focus,
   .vue-flow__node-output:focus-visible {
      outline: none;
-     border: 1px solid #555;
+     border: 0.5px solid #555;
    }
 
 .vue-flow__node {


### PR DESCRIPTION
## Summary
- refine node style in bright/dark themes
- use thinner default borders in Vue Flow

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d181a78d08330a4df8e192ebbd173