### PR TITLE
Add deduplication sidebar button

### DIFF
--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -74,5 +74,7 @@
   "ancestorsOnly": "Vorfahren",
   "descendantsOnly": "Nachkommen",
   "both": "Beides",
-  "viewBloodline": "Gefilterten Baum anzeigen"
+  "viewBloodline": "Gefilterten Baum anzeigen",
+  "deduplicate": "Duplikate finden",
+  "skipAll": "Alle \u00fcberspringen"
 }

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -74,5 +74,7 @@
   "ancestorsOnly": "Ancestors",
   "descendantsOnly": "Descendants",
   "both": "Both",
-  "viewBloodline": "View Bloodline"
+  "viewBloodline": "View Bloodline",
+  "deduplicate": "Deduplicate",
+  "skipAll": "Skip All"
 }


### PR DESCRIPTION
## Summary
- add utility import for `matchScore`
- implement `runDedup` to check existing people for duplicates
- show progress and allow skipping all duplicate conflicts
- expose dedup action via sidebar icon button
- translate new UI strings in EN and DE locales

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d381ffc5c8330a2eb566364bdec9f