### PR TITLE
Fix user modal activation via username

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -260,6 +260,9 @@
     #themeToggleContainer {
       margin-right: 0.5rem;
     }
+    #userLabel {
+      cursor: pointer;
+    }
     .context-menu {
       position: absolute;
       background: #fff;
@@ -456,6 +459,7 @@
       if (AppConfig.loginEnabled) {
         loginBtn.style.display = 'inline-block';
         loginBtn.addEventListener('click', () => { loginModal.style.display = 'flex'; });
+        userLabel.addEventListener('click', () => { loginModal.style.display = 'flex'; });
         loginSubmit.addEventListener('click', async () => {
           await fetch('/api/login', {
             method: 'POST',


### PR DESCRIPTION
## Summary
- make the username clickable
- open login modal when clicking the username

## Testing
- `cd frontend && npm run lint && npm test`
- `cd backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d83650f9c8330809775a5b2093230