### PR TITLE
Fix user profile modal trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You can also tweak how tightly related nodes are drawn together by setting
 `RELATIVE_ATTRACTION` (0 = loose layout, 1 = very compact). It defaults to `0.5`.
 The bulk delete button is hidden by default. Set `SHOW_DELETE_ALL_BUTTON=true`
 if you want to display it in the toolbar.
+Authentication can be toggled with `LOGIN_ENABLED`. Set it to `true` to enable
+the login dialog and LDAP authentication. The default is `false`.
 
 ### Running with Prebuilt Images
 

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -44,6 +44,7 @@ services:
       BACKEND_PORT: ${BACKEND_PORT:-3009}
       RELATIVE_ATTRACTION: ${RELATIVE_ATTRACTION:-0.5}
       SHOW_DELETE_ALL_BUTTON: ${SHOW_DELETE_ALL_BUTTON:-false}
+      LOGIN_ENABLED: ${LOGIN_ENABLED:-false}
     ports:
       - '${FRONTEND_PORT:-8080}:80'
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       BACKEND_PORT: ${BACKEND_PORT:-3009}
       RELATIVE_ATTRACTION: ${RELATIVE_ATTRACTION:-0.5}
       SHOW_DELETE_ALL_BUTTON: ${SHOW_DELETE_ALL_BUTTON:-false}
+      LOGIN_ENABLED: ${LOGIN_ENABLED:-false}
     ports:
       - '8080:80'
     depends_on:

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 # Substitute BACKEND_PORT env var into nginx config
-envsubst '$BACKEND_PORT $RELATIVE_ATTRACTION $SHOW_DELETE_ALL_BUTTON' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '$BACKEND_PORT $RELATIVE_ATTRACTION $SHOW_DELETE_ALL_BUTTON $LOGIN_ENABLED' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 # Substitute relative attraction into client config
 if [ -f /usr/share/nginx/html/src/config.js ]; then
-  envsubst '$RELATIVE_ATTRACTION $SHOW_DELETE_ALL_BUTTON' < /usr/share/nginx/html/src/config.js > /usr/share/nginx/html/src/config.js.tmp \
+  envsubst '$RELATIVE_ATTRACTION $SHOW_DELETE_ALL_BUTTON $LOGIN_ENABLED' < /usr/share/nginx/html/src/config.js > /usr/share/nginx/html/src/config.js.tmp \
     && mv /usr/share/nginx/html/src/config.js.tmp /usr/share/nginx/html/src/config.js
 fi
 exec nginx -g 'daemon off;'

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -456,10 +456,12 @@
         } catch (e) { /* ignore */ }
       }
 
+      // allow opening the login/profile modal when tapping the user label
+      userLabel.addEventListener('click', () => { loginModal.style.display = 'flex'; });
+
       if (AppConfig.loginEnabled) {
         loginBtn.style.display = 'inline-block';
         loginBtn.addEventListener('click', () => { loginModal.style.display = 'flex'; });
-        userLabel.addEventListener('click', () => { loginModal.style.display = 'flex'; });
         loginSubmit.addEventListener('click', async () => {
           await fetch('/api/login', {
             method: 'POST',


### PR DESCRIPTION
## Summary
- enable opening login modal by tapping the username label
- toggle login modal via `LOGIN_ENABLED` env var and support it in docker-compose

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d9c2093f883308a11d507e012d332