### PR TITLE
Fix immediate "me" node update and focus

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -463,6 +463,7 @@
           });
           window.meNodeId = selected.value.id;
           if (window.FlowApp && window.FlowApp.refreshMe) window.FlowApp.refreshMe();
+          selected.value.me = true;
         }
 
         function handleKeydown(ev) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -493,7 +493,7 @@
 
       FrontendApp.mountApp();
       FlowApp.mount();
-      window.gotoMe = () => { if (meNodeId) FlowApp.focusNode(meNodeId); };
+      window.gotoMe = () => { if (window.meNodeId) FlowApp.focusNode(window.meNodeId); };
       refreshUser();
       if (FlowApp.refreshMe) FlowApp.refreshMe();
       if (window.SearchApp) {


### PR DESCRIPTION
## Summary
- ensure detail modal star is updated when "Set as Me" is clicked
- use global `window.meNodeId` for focus button so it works immediately

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685da0bf38f08330ab3ec1ff877c6ce5