### PR TITLE
Add leaderboard and scoring

### DIFF
--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -24,6 +24,7 @@ const sequelize = new Sequelize(
 const Person = require('./person')(sequelize);
 const Marriage = require('./marriage')(sequelize);
 const Layout = require('./layout')(sequelize);
+const Score = require('./score')(sequelize);
 
 Person.belongsTo(Person, { as: 'father', foreignKey: 'fatherId' });
 Person.belongsTo(Person, { as: 'mother', foreignKey: 'motherId' });
@@ -40,4 +41,4 @@ Person.belongsToMany(Person, {
   otherKey: 'personId',
 });
 
-module.exports = { sequelize, Person, Marriage, Layout };
+module.exports = { sequelize, Person, Marriage, Layout, Score };

--- a/backend/src/models/score.js
+++ b/backend/src/models/score.js
@@ -1,0 +1,12 @@
+const { DataTypes, Model } = require('sequelize');
+module.exports = (sequelize) => {
+  class Score extends Model {}
+  Score.init(
+    {
+      username: { type: DataTypes.STRING, primaryKey: true },
+      points: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    },
+    { sequelize, modelName: 'Score' }
+  );
+  return Score;
+};

--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -88,4 +88,7 @@
   ,"name": "Name"
   ,"email": "E-Mail"
   ,"myNode": "Mein Knoten"
+  ,"leaderboard": "Bestenliste"
+  ,"points": "Punkte"
+  ,"rank": "Rang"
 }

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -88,4 +88,7 @@
   ,"name": "Name"
   ,"email": "Email"
   ,"myNode": "My node"
+  ,"leaderboard": "Leaderboard"
+  ,"points": "Points"
+  ,"rank": "Rank"
 }


### PR DESCRIPTION
## Summary
- implement Score model and update backend APIs
- award points when creating and updating people
- expose `/api/score` and `/api/scores` for leaderboard
- display current score with trophy icon in canvas
- add leaderboard modal in the frontend
- update i18n translations

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db581b7508330aa1d038c363aa299