### PR TITLE
Add loading overlay for flow canvas

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -94,6 +94,8 @@
               : null)) || 0.5;
         const showDeleteAllButton =
           !!(window.AppConfig && AppConfig.showDeleteAllButton);
+        const loadingEl = document.getElementById('loadingOverlay');
+        function setLoading(v) { if (loadingEl) loadingEl.style.display = v ? 'flex' : 'none'; }
         const selected = ref(null);
         const showModal = ref(false);
         const contextMenuVisible = ref(false);
@@ -237,6 +239,7 @@
         }
 
         async function load(preservePositions = false) {
+          setLoading(true);
           const existingPos = {};
           if (preservePositions) {
             nodes.value.forEach((n) => {
@@ -391,6 +394,7 @@
           refreshUnions();
           saveTempLayout();
           applyFilters();
+          setLoading(false);
         }
 
         const children = ref([]);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -130,6 +130,21 @@
     body.multi-select-active #flow-app {
       cursor: crosshair;
     }
+    #loadingOverlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255,255,255,0.8);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 15;
+    }
+    body.dark-theme #loadingOverlay {
+      background: rgba(0,0,0,0.8);
+    }
     #multiIndicator {
       position: absolute;
       top: 10px;
@@ -363,6 +378,11 @@
       </div>
     </div>
         <div id="flow-app" style="touch-action: none; overflow: hidden;">
+          <div id="loadingOverlay" style="display:flex;">
+            <div class="spinner-border text-primary" role="status">
+              <span class="sr-only" data-i18n="loading">Loading...</span>
+            </div>
+          </div>
           <div id="multiIndicator" data-i18n="multiSelect">Multi-select</div>
         </div>
       </div>

--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -91,4 +91,5 @@
   ,"leaderboard": "Bestenliste"
   ,"points": "Punkte"
   ,"rank": "Rang"
+  ,"loading": "Wird geladen..."
 }

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -91,4 +91,5 @@
   ,"leaderboard": "Leaderboard"
   ,"points": "Points"
   ,"rank": "Rank"
+  ,"loading": "Loading..."
 }

--- a/frontend/src/lang/pl.json
+++ b/frontend/src/lang/pl.json
@@ -91,4 +91,5 @@
   ,"leaderboard": "Ranking"
   ,"points": "Punkty"
   ,"rank": "Ranga"
+  ,"loading": "Ladowanie..."
 }


### PR DESCRIPTION
## Summary
- add loading overlay element and styles
- translate "Loading" text in all languages
- block interactions until flow is loaded

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e265a78608330aca90c9629b7fb4d