### PR TITLE
Move 'me' star inside detail modal header

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -2200,15 +2200,16 @@
                 <template v-if="!editing && !isNew">
                   <div class="d-flex align-items-center mb-3" style="position:relative;">
                     <img :src="avatarSrc(selected.gender, 80)" class="avatar-placeholder mr-3" data-i18n-alt="avatar" />
+                    <span
+                      v-if="selected.me"
+                      class="mx-1"
+                      style="color:#f39c12;font-size:28px;"
+                    >&#9733;</span>
                     <div class="name-container">
                       <div class="h4 mb-0" :style="{ fontSize: (selected.callName || selected.firstName) && (selected.callName || selected.firstName).length > 15 ? '1rem' : '1.25rem' }">{{ selected.callName || selected.firstName }}</div>
                       <div v-if="selected.callName" class="h4 mb-0" :style="{ fontSize: selected.firstName && selected.firstName.length > 15 ? '1rem' : '1.25rem' }">({{ selected.firstName }})</div>
                       <div class="h4 mb-0" :style="{ fontSize: selected.lastName && selected.lastName.length > 15 ? '1rem' : '1.25rem' }">{{ selected.lastName }}</div>
                     </div>
-                    <span
-                      v-if="selected.me"
-                      style="position:absolute;top:-18px;right:-18px;color:#f39c12;font-size:28px;"
-                    >&#9733;</span>
                   </div>
                   <p v-if="selected.maidenName"><strong data-i18n="maidenNameLabel">Maiden Name:</strong> {{ selected.maidenName }}</p>
                   <p


### PR DESCRIPTION
## Summary
- update detail modal header so the "it's me" star displays next to the avatar

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e36d8c5588330878cb0320dc840e5