### PR TITLE
Fix infinite scroll for place suggestions

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -140,9 +140,9 @@
         const leaderboard = ref([]);
         const placeSuggestions = ref([]);
         const placeDisplayCount = ref(5);
-        function visiblePlaceSuggestions() {
-          return placeSuggestions.value.slice(0, placeDisplayCount.value);
-        }
+        const visiblePlaceSuggestions = computed(() =>
+          placeSuggestions.value.slice(0, placeDisplayCount.value)
+        );
         const placeFocus = ref(false);
         const filters = ref({
           missingParents: false,
@@ -2347,7 +2347,7 @@
                       </label>
                       <input class="form-control" v-model="selected.placeOfBirth" placeholder="City or town" title="Place of birth" data-i18n-placeholder="placeOfBirth" @focus="placeFocus=true; onPlaceInput($event)" @blur="hidePlaceDropdown" @input="onPlaceInput" />
                       <ul v-if="placeFocus && placeSuggestions.length" class="list-group position-absolute" style="top:100%; left:0; right:0; z-index:1000; max-height:150px; overflow-y:auto;" @scroll="onPlaceScroll">
-        <li v-for="s in visiblePlaceSuggestions()" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPlace(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
+        <li v-for="s in visiblePlaceSuggestions" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPlace(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
                         <li class="list-group-item list-group-item-action" @mousedown.prevent="useTypedPlace" data-i18n="useExactly">Use Exactly</li>
                       </ul>
                     </div>


### PR DESCRIPTION
## Summary
- make place suggestion list reactive so more results render on scroll
- adjust template to use computed suggestion list

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e3ba4e944833092cd218061d6c1ed