### PR TITLE
Show login error message

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -400,6 +400,7 @@
         <label for="loginPass" data-i18n="password">Password</label>
         <input id="loginPass" name="password" autocomplete="current-password" type="password" class="form-control" />
       </div>
+      <div id="loginError" class="text-danger mb-2" data-i18n="loginError" style="display:none;"></div>
       <div class="text-right">
         <button id="guestBtn" class="btn btn-secondary btn-sm mr-2" data-i18n="guest">Guest</button>
         <button id="loginSubmit" class="btn btn-primary btn-sm" data-i18n="login">Login</button>
@@ -516,6 +517,7 @@
       const loginUser = document.getElementById('loginUser');
       const loginPass = document.getElementById('loginPass');
       const loginSubmit = document.getElementById('loginSubmit');
+      const loginError = document.getElementById('loginError');
       const guestBtn = document.getElementById('guestBtn');
 
       async function refreshUser() {
@@ -562,16 +564,25 @@
         loginBtn.style.display = 'inline-block';
         loginBtn.addEventListener('click', () => { loginModal.style.display = 'flex'; });
         loginSubmit.addEventListener('click', async () => {
-          await fetch('/api/login', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username: loginUser.value, password: loginPass.value })
-          });
-          loginModal.style.display = 'none';
-          loginUser.value = '';
-          loginPass.value = '';
-          refreshUser();
-          if (FlowApp.refreshMe) FlowApp.refreshMe();
+          try {
+            const res = await fetch('/api/login', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ username: loginUser.value, password: loginPass.value })
+            });
+            if (!res.ok) {
+              loginError.style.display = 'block';
+              return;
+            }
+            loginModal.style.display = 'none';
+            loginUser.value = '';
+            loginPass.value = '';
+            loginError.style.display = 'none';
+            refreshUser();
+            if (FlowApp.refreshMe) FlowApp.refreshMe();
+          } catch (e) {
+            loginError.style.display = 'block';
+          }
         });
         guestBtn.addEventListener('click', async () => {
           await fetch('/api/login', {
@@ -580,6 +591,7 @@
             body: JSON.stringify({ username: 'guest' })
           });
           loginModal.style.display = 'none';
+          loginError.style.display = 'none';
           refreshUser();
           if (FlowApp.refreshMe) FlowApp.refreshMe();
         });
@@ -593,6 +605,7 @@
       function closeModals() {
         loginModal.style.display = 'none';
         profileModal.style.display = 'none';
+        loginError.style.display = 'none';
       }
 
       loginModal.addEventListener('click', (e) => { if (e.target === loginModal) closeModals(); });

--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -82,6 +82,7 @@
   ,"username": "Benutzername"
   ,"password": "Passwort"
   ,"guest": "Gast"
+  ,"loginError": "Ung\u00fcltiger Benutzername oder Passwort"
   ,"setAsMe": "Als mich festlegen"
   ,"gotoMe": "Zu mir"
   ,"profile": "Profil"

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -82,6 +82,7 @@
   ,"username": "Username"
   ,"password": "Password"
   ,"guest": "Guest"
+  ,"loginError": "Invalid username or password"
   ,"setAsMe": "Set as Me"
   ,"gotoMe": "Go to Me"
   ,"profile": "Profile"

--- a/frontend/src/lang/pl.json
+++ b/frontend/src/lang/pl.json
@@ -82,6 +82,7 @@
   ,"username": "Nazwa uzytkownika"
   ,"password": "Haslo"
   ,"guest": "Gosc"
+  ,"loginError": "Nieprawid\u0142owa nazwa u\u017cytkownika lub has\u0142o"
   ,"setAsMe": "Ustaw jako mnie"
   ,"gotoMe": "Idz do mnie"
   ,"profile": "Profil"


### PR DESCRIPTION
## Summary
- display login error text in login modal
- handle invalid login attempts and show message
- add translations for new login error string

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e3b704a448330b5ee33a5a71e9be5