### PR TITLE
Fix session persistence

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,13 +10,14 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "connect-session-sequelize": "^7.1.5",
     "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "ldapauth-fork": "^6.0.1",
     "pg": "^8.11.3",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.32.1",
-    "sqlite3": "^5.1.6",
-    "express-session": "^1.17.3",
-    "ldapauth-fork": "^6.0.1"
+    "sqlite3": "^5.1.6"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -7,6 +7,7 @@ const { sequelize } = require('../src/models');
 
 beforeAll(async () => {
   await sequelize.sync({ force: true });
+  await app.sessionStore.sync();
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Summary
- persist session data in the backend database using `connect-session-sequelize`
- create the sessions table on startup
- expose the session store for tests
- ensure tests initialise the session store

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e6b2e026883309b2fb7a8e3811c98