### PR TITLE
Fix iOS long‑press context menu

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,11 @@
       float: left;
       width: calc(100% - 250px);
       touch-action: none;
+      -webkit-user-select: none;
+         -moz-user-select: none;
+          -ms-user-select: none;
+              user-select: none;
+      -webkit-touch-callout: none;
       height: calc(100vh - 90px);
       position: relative;
     }


### PR DESCRIPTION
## Summary
- prevent iOS from selecting text when long-pressing on the VueFlow canvas by disabling user selection and touch callouts

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e77f013548330a0f7be6c61141ce5