### PR TITLE
Fix GeoNames search filter for multiword places

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -317,7 +317,7 @@ async function geonamesSuggest(query, lang = 'en', cc = '') {
     const data = await resp.json();
     let res = Array.isArray(data.geonames) ? data.geonames : [];
     if (!/County|Province|District/i.test(q)) {
-      res = res.filter((r) => ['PPL', 'PPLA', 'PPLC'].includes(r.fcode));
+      res = res.filter((r) => r.fcode && r.fcode.startsWith('PPL'));
     }
     res.sort((a, b) => {
       const pa = regionPriority(a.countryCode);


### PR DESCRIPTION
## Summary
- allow GeoNames suggestion lookups to return codes like `PPLA3`

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ed6939258833092c317eac5acb26c