### PR TITLE
Fix long press context menu

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -601,6 +601,13 @@
           );
           window.addEventListener('keydown', handleKeydown);
           window.addEventListener('keyup', handleKeyup);
+          const flowEl = document.getElementById('flow-app');
+          if (flowEl) {
+            flowEl.addEventListener('contextmenu', handleContextMenu);
+            flowEl.addEventListener('touchstart', handleTouchStart);
+            flowEl.addEventListener('touchend', handleTouchEnd);
+            flowEl.addEventListener('touchcancel', handleTouchEnd);
+          }
           fetchScore();
           scoreTimer = setInterval(fetchScore, 10000);
         });
@@ -608,6 +615,13 @@
         onBeforeUnmount(() => {
           window.removeEventListener('keydown', handleKeydown);
           window.removeEventListener('keyup', handleKeyup);
+          const flowEl = document.getElementById('flow-app');
+          if (flowEl) {
+            flowEl.removeEventListener('contextmenu', handleContextMenu);
+            flowEl.removeEventListener('touchstart', handleTouchStart);
+            flowEl.removeEventListener('touchend', handleTouchEnd);
+            flowEl.removeEventListener('touchcancel', handleTouchEnd);
+          }
           if (scoreTimer) clearInterval(scoreTimer);
         });
         const editing = ref(false);


### PR DESCRIPTION
## Summary
- handle long press on canvas by attaching touch handlers to `#flow-app`
- remove those listeners on unmount

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ede2e94588330b655f188e51f6c8c