### PR TITLE
Refine deduplication matching

### DIFF
--- a/frontend/src/utils/dedup.js
+++ b/frontend/src/utils/dedup.js
@@ -65,6 +65,24 @@
     return score;
   }
 
+  function attributeMatchCount(p, e) {
+    let count = 0;
+    const ln = (p.lastName || '').toLowerCase();
+    const ln2 = (e.lastName || '').toLowerCase();
+    const mn2 = (e.maidenName || '').toLowerCase();
+    if ((ln && ln2 && ln === ln2) || (ln && mn2 && ln === mn2)) count += 1;
+
+    if (similarity(p.firstName, e.firstName) >= 0.8) count += 1;
+
+    const yearP = getYear(p.dateOfBirth || p.birthApprox);
+    const yearE = getYear(e.dateOfBirth || e.birthApprox);
+    if (yearP && yearE && Math.abs(yearP - yearE) <= 1) count += 1;
+
+    if (similarity(p.placeOfBirth, e.placeOfBirth) >= 0.8) count += 1;
+
+    return count;
+  }
+
   function findBestMatch(person, existing) {
     let best = null;
     let bestScore = 0;
@@ -73,6 +91,8 @@
         return { match: e, score: 100 };
       }
       const sc = matchScore(person, e);
+      const matches = attributeMatchCount(person, e);
+      if (matches <= 1) continue;
       if (sc > bestScore) {
         best = e;
         bestScore = sc;

--- a/frontend/test/dedup.test.js
+++ b/frontend/test/dedup.test.js
@@ -17,4 +17,13 @@ describe('deduplication utils', () => {
     const c = { firstName: 'Beth', lastName: 'Jones', dateOfBirth: '1880-01-01' };
     expect(matchScore(a, b)).toBeGreaterThan(matchScore(a, c));
   });
+
+  test('single fuzzy attribute does not trigger match', () => {
+    const existing = [
+      { id: 1, firstName: 'John', lastName: 'Smith', dateOfBirth: '1900-01-01', placeOfBirth: 'Berlin' },
+    ];
+    const person = { firstName: 'Jon', lastName: 'Doe' };
+    const { match } = findBestMatch(person, existing);
+    expect(match).toBe(null);
+  });
 });


### PR DESCRIPTION
## Summary
- ignore potential duplicates when only one field matches
- add test to ensure a single fuzzy match isn't considered a duplicate

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ee599c078833098d4c25585d169aa