### PR TITLE
Add admin info and score reset controls

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -703,6 +703,11 @@ app.get('/api/scores', async (_req, res) => {
   res.json(scores);
 });
 
+app.post('/api/score/reset', requireAdmin, async (_req, res) => {
+  await Score.update({ points: 0 }, { where: {} });
+  res.sendStatus(204);
+});
+
 app.get('/api/activity', async (_req, res) => {
   const logs = await Activity.findAll({ order: [['createdAt', 'DESC']] });
   res.json(logs);

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1141,6 +1141,11 @@
           showScores.value = true;
         }
 
+        async function resetScores() {
+          await fetch('/api/score/reset', { method: 'POST' });
+          openScores();
+        }
+
         openScoresFn = openScores;
 
         function triggerSearch() {
@@ -1969,6 +1974,7 @@
         showDeleteAllButton,
         runDedup,
         openScores,
+        resetScores,
         showScores,
         myScore,
         leaderboard,
@@ -2188,7 +2194,8 @@
               </tbody>
             </table>
             <div class="text-right mt-2">
-              <button class="btn btn-primary btn-sm mr-2" @click="showScores = false" data-i18n="close">Close</button>
+              <button v-if="admin" class="btn btn-danger btn-sm mr-2" @click="resetScores" data-i18n="resetScores">Reset</button>
+              <button class="btn btn-primary btn-sm" @click="showScores = false" data-i18n="close">Close</button>
             </div>
           </div>
         </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -315,6 +315,9 @@
     #userLabel {
       cursor: pointer;
     }
+    #scoreTrigger {
+      cursor: pointer;
+    }
     .context-menu {
       position: absolute;
       background: #fff;
@@ -350,10 +353,10 @@
           <div class="d-flex align-items-center">
             <button id="loginBtn" class="btn btn-sm btn-secondary ml-2" style="display:none;" data-i18n="login">Login</button>
             <span id="userLabel" class="ml-2"></span>
-            <button id="scoreTrigger" class="icon-button d-flex align-items-center ml-2" data-i18n-title="leaderboard" title="Leaderboard">
+            <span id="scoreTrigger" class="d-flex align-items-center ml-2" data-i18n-title="leaderboard" title="Leaderboard" style="cursor:pointer;">
               <span class="material-icons" style="color:#f0ad4e;font-size:18px;">emoji_events</span>
               <span id="scoreValue" class="ml-1" style="font-size:0.8rem;"></span>
-            </button>
+            </span>
           </div>
         </div>
     </header>
@@ -452,6 +455,7 @@
       <img id="profileAvatar" class="rounded-circle mb-2" style="width:96px;height:96px;object-fit:cover;display:none;" alt="" data-i18n-alt="avatar" />
       <h4 data-i18n="profile" id="profileTitle">Profile</h4>
       <p id="profileUsername" class="mb-1"></p>
+      <p id="profileRole" class="mb-1"></p>
       <p id="profileName" class="mb-1"></p>
       <p id="profileEmail" class="mb-1"></p>
       <p id="profileNode" class="mb-2"></p>
@@ -554,6 +558,7 @@
       const profileModal = document.getElementById('profileModal');
       const profileAvatar = document.getElementById('profileAvatar');
       const profileUsername = document.getElementById('profileUsername');
+      const profileRole = document.getElementById('profileRole');
       const profileName = document.getElementById('profileName');
       const profileEmail = document.getElementById('profileEmail');
       const profileNode = document.getElementById('profileNode');
@@ -582,8 +587,14 @@
           }
           window.meNodeId = meNodeId;
           userLabel.textContent = data.username || '';
-          profileUsername.textContent = data.username || '';
-          profileName.textContent = data.name ? `${I18n.t('name')}: ${data.name}` : '';
+      profileUsername.textContent = data.username || '';
+          profileRole.textContent =
+            data.username && data.username !== 'guest'
+              ? data.admin
+                ? I18n.t('roleAdmin')
+                : I18n.t('roleUser')
+              : '';
+      profileName.textContent = data.name ? `${I18n.t('name')}: ${data.name}` : '';
           profileEmail.textContent = data.email ? `${I18n.t('email')}: ${data.email}` : '';
           profileNode.textContent = meNodeId ? `${I18n.t('myNode')}: ${meNodeId}` : '';
           if (data.avatar) {

--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -92,5 +92,8 @@
   ,"leaderboard": "Bestenliste"
   ,"points": "Punkte"
   ,"rank": "Rang"
+  ,"roleAdmin": "Administrator"
+  ,"roleUser": "Benutzer"
+  ,"resetScores": "Punkte zur\u00fccksetzen"
   ,"loading": "Wird geladen..."
 }

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -92,5 +92,8 @@
   ,"leaderboard": "Leaderboard"
   ,"points": "Points"
   ,"rank": "Rank"
+  ,"roleAdmin": "Admin"
+  ,"roleUser": "User"
+  ,"resetScores": "Reset Scores"
   ,"loading": "Loading..."
 }

--- a/frontend/src/lang/pl.json
+++ b/frontend/src/lang/pl.json
@@ -92,5 +92,8 @@
   ,"leaderboard": "Ranking"
   ,"points": "Punkty"
   ,"rank": "Ranga"
+  ,"roleAdmin": "Administrator"
+  ,"roleUser": "U\u017cytkownik"
+  ,"resetScores": "Zresetuj punkty"
   ,"loading": "Ladowanie..."
 }


### PR DESCRIPTION
## Summary
- show admin or user role in profile modal
- style score display as inline text and keep click handling
- allow admins to reset the leaderboard
- expose score reset button for admins only
- add new translations for role labels and reset button

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860111c75388330a693d794b218cdad