### PR TITLE
Add configurable proxy group names

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ To integrate with an external SSO proxy such as Authelia, set
 (comma-separated). When a request from a trusted IP includes the
 `X-Remote-User` header, the backend automatically creates a session for that
 user. Otherwise the standard LDAP login form is shown.
+Set `PROXY_ADMIN_GROUP` and `PROXY_USER_GROUP` if your SSO solution uses
+different group names than the defaults of `familytree_admin` and
+`familytree_user`.
 
 ### Running with Prebuilt Images
 

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -33,6 +33,8 @@ services:
       SESSION_SECRET: ${SESSION_SECRET}
       USE_PROXY_AUTH: ${USE_PROXY_AUTH:-false}
       TRUSTED_PROXY_IPS: ${TRUSTED_PROXY_IPS:-}
+      PROXY_ADMIN_GROUP: ${PROXY_ADMIN_GROUP:-familytree_admin}
+      PROXY_USER_GROUP: ${PROXY_USER_GROUP:-familytree_user}
       NODE_ENV: ${NODE_ENV:-production}
     ports:
       - '${BACKEND_PORT:-3009}:${BACKEND_PORT:-3009}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       SESSION_SECRET: ${SESSION_SECRET}
       USE_PROXY_AUTH: ${USE_PROXY_AUTH:-false}
       TRUSTED_PROXY_IPS: ${TRUSTED_PROXY_IPS:-}
+      PROXY_ADMIN_GROUP: ${PROXY_ADMIN_GROUP:-familytree_admin}
+      PROXY_USER_GROUP: ${PROXY_USER_GROUP:-familytree_user}
       NODE_ENV: ${NODE_ENV:-development}
     ports:
       - '${BACKEND_PORT:-3009}:${BACKEND_PORT:-3009}'


### PR DESCRIPTION
## Summary
- check proxy authentication groups for configured admin/user names
- allow custom group names via `PROXY_ADMIN_GROUP` and `PROXY_USER_GROUP`
- document the new variables
- expose them in docker compose files

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68606ba22b7883309aecff9d39b9509b