### PR TITLE
Fix PoB suggestion selection

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -171,7 +171,6 @@
           this.$nextTick(() => {
             this.pobSuggestions = [];
             this.pobFocus = false;
-            if (document.activeElement) document.activeElement.blur();
           });
         },
         useTypedPob() {

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -956,7 +956,6 @@
           nextTick(() => {
             placeSuggestions.value = [];
             placeFocus.value = false;
-            if (document.activeElement) document.activeElement.blur();
           });
         }
 
@@ -2391,8 +2390,8 @@
                       </label>
                       <input class="form-control" v-model="selected.placeOfBirth" placeholder="City or town" title="Place of birth" data-i18n-placeholder="placeOfBirth" @focus="placeFocus=true; onPlaceInput($event)" @blur="hidePlaceDropdown" @input="onPlaceInput" />
                       <ul v-if="placeFocus && placeSuggestions.length" class="list-group position-absolute" style="top:100%; left:0; right:0; z-index:1000; max-height:150px; overflow-y:auto;" @scroll="onPlaceScroll">
-        <li v-for="s in visiblePlaceSuggestions" :key="s.geonameId" class="list-group-item list-group-item-action" @click.prevent="applyPlace(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
-                        <li class="list-group-item list-group-item-action" @click.prevent="useTypedPlace" data-i18n="useExactly">Use Exactly</li>
+        <li v-for="s in visiblePlaceSuggestions" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPlace(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
+                        <li class="list-group-item list-group-item-action" @mousedown.prevent="useTypedPlace" data-i18n="useExactly">Use Exactly</li>
                       </ul>
                     </div>
                   </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -414,8 +414,8 @@
             </label>
             <input class="form-control mb-2" v-model="selectedPerson.placeOfBirth" placeholder="Place of Birth" data-i18n-placeholder="placeOfBirth" @focus="pobFocus=true; onPobInput($event)" @blur="hidePobDropdown" @input="onPobInput">
             <ul v-if="pobFocus && pobSuggestions.length" class="list-group position-absolute" style="top:100%; left:0; right:0; z-index:1000; max-height:150px; overflow-y:auto;" @scroll="onPobScroll">
-              <li v-for="s in visiblePobSuggestions" :key="s.geonameId" class="list-group-item list-group-item-action" @click.prevent="applyPob(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
-              <li class="list-group-item list-group-item-action" @click.prevent="useTypedPob" data-i18n="useExactly">Use Exactly</li>
+              <li v-for="s in visiblePobSuggestions" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPob(s)">{{ s.name }}<span v-if="s.postalCode"> ({{ s.postalCode }})</span><span v-if="s.adminName1">, {{ s.adminName1 }}</span> {{ s.countryCode }}</li>
+              <li class="list-group-item list-group-item-action" @mousedown.prevent="useTypedPob" data-i18n="useExactly">Use Exactly</li>
             </ul>
           </div>
           <div class="col">

--- a/frontend/test/pob.test.js
+++ b/frontend/test/pob.test.js
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const FrontendApp = require('../app');
+
+function loadVue() {
+  const sandbox = { window, document, navigator, console, SVGElement: window.SVGElement, Element: window.Element };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(path.join(__dirname, '../vue.global.js'), 'utf8'), sandbox);
+  global.Vue = sandbox.Vue;
+  return sandbox.Vue;
+}
+
+describe('place of birth suggestions', () => {
+  let Vue;
+  let vmApp;
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <div id="app">
+        <div v-if="selectedPerson" class="edit-section">
+          <input id="pobInput" v-model="selectedPerson.placeOfBirth"
+            @focus="pobFocus=true" @blur="hidePobDropdown" @input="onPobInput">
+          <ul v-if="pobFocus && pobSuggestions.length">
+            <li v-for="s in visiblePobSuggestions" :key="s.geonameId" class="list-group-item list-group-item-action" @mousedown.prevent="applyPob(s)">{{ s.name }}</li>
+            <li class="list-group-item list-group-item-action" @mousedown.prevent="useTypedPob">Use Exactly</li>
+          </ul>
+        </div>
+      </div>`;
+    Vue = loadVue();
+    global.fetch = jest.fn().mockResolvedValue({ json: () => [] });
+    vmApp = FrontendApp.mountApp();
+    await Vue.nextTick();
+    vmApp.selectedPerson = { id: 1, placeOfBirth: '', geonameId: null };
+  });
+
+  afterEach(() => {
+    delete global.Vue;
+    jest.resetAllMocks();
+  });
+
+  test('selecting suggestion updates person', async () => {
+    vmApp.pobSuggestions = [{ geonameId: 7, name: 'Foo', countryCode: 'US' }];
+    vmApp.pobFocus = true;
+    await Vue.nextTick();
+    const item = document.querySelector('li.list-group-item');
+    item.dispatchEvent(new Event('mousedown', { bubbles: true }));
+    await Vue.nextTick();
+    expect(vmApp.selectedPerson.placeOfBirth).toContain('Foo');
+    expect(vmApp.selectedPerson.geonameId).toBe(7);
+    expect(vmApp.pobSuggestions.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- fix place selection by using `mousedown` event so blur doesn't interfere
- add regression test for selecting a place of birth
- remove manual blur after selecting a place to avoid DOM patch errors

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_686062edf4cc833081844a3676083dd5