### PR TITLE
Fix minor frontend issues

### DIFF
--- a/frontend/search.js
+++ b/frontend/search.js
@@ -43,11 +43,14 @@
       overlay.style.display = 'none';
       overlay.innerHTML = `
         <div class="modal-content card p-3" style="min-width: 300px;">
-          <input type="text" id="search-input" class="form-control mb-2" placeholder="Search..." />
+          <input type="text" id="search-input" class="form-control mb-2" data-i18n-placeholder="search" />
           <ul id="search-results" class="list-group" style="max-height:200px;overflow-y:auto"></ul>
         </div>`;
       overlay.addEventListener('click', (e) => { if (e.target === overlay) hide(); });
       document.body.appendChild(overlay);
+      if (root.I18n && typeof root.I18n.updateDom === 'function') {
+        root.I18n.updateDom();
+      }
     }
     const input = overlay.querySelector('#search-input');
     if (!input.dataset.bound) {

--- a/frontend/src/utils/dedup.js
+++ b/frontend/src/utils/dedup.js
@@ -8,7 +8,8 @@
   function levenshtein(a = '', b = '') {
     const dp = Array.from({ length: b.length + 1 }, (_, i) => i);
     for (let i = 1; i <= a.length; i++) {
-      let prev = i;
+      let prev = dp[0];
+      dp[0] = i;
       for (let j = 1; j <= b.length; j++) {
         const tmp = dp[j];
         dp[j] = Math.min(

--- a/frontend/src/utils/exportSvg.js
+++ b/frontend/src/utils/exportSvg.js
@@ -21,7 +21,13 @@
 
     var svg;
     if (svgEl) {
-      var bb = svgEl.getBBox();
+      var bb;
+      try {
+        bb = svgEl.getBBox();
+      } catch (e) {
+        var rect = svgEl.getBoundingClientRect();
+        bb = { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+      }
       svg = svgEl.cloneNode(true);
       svg.setAttribute('viewBox', bb.x + ' ' + bb.y + ' ' + bb.width + ' ' + bb.height);
       svg.setAttribute('width', bb.width);


### PR DESCRIPTION
## Summary
- correct Levenshtein distance calculation in dedup utils
- handle `getBBox` failures when exporting SVG
- localise search input placeholder

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68614acb57f8833097fd79dee007641a