### PR TITLE
Fix admin flag missing in /api/me

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -231,9 +231,6 @@ app.get('/debug/headers', (req, res) => {
 });
 
 app.get('/api/me', async (req, res) => {
-  if (req.user) {
-    return res.json(req.user);
-  }
   const username = req.session.user || 'guest';
   let nodeId = req.session.meNodeId || null;
   if (username !== 'guest' && !nodeId) {


### PR DESCRIPTION
## Summary
- ensure `/api/me` always responds with session data

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861807a3f448330831cb03ecb0ba8f4