### PR TITLE
Fix modal update after place selection

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -969,6 +969,8 @@
           console.log('[applyPlace] suggestions cleared');
           placeFocus.value = false;
           if (document.activeElement) document.activeElement.blur();
+          showModal.value = false;
+          await nextTick();
           await FrontendApp.updatePerson(selected.value.id, {
             placeOfBirth: full,
             geonameId: s.geonameId,
@@ -984,9 +986,8 @@
           }
           editing.value = true;
           showModal.value = true;
-          nextTick(() => {
-            console.log('[applyPlace] update complete');
-          });
+          await nextTick();
+          console.log('[applyPlace] update complete');
         }
 
         function useTypedPlace() {


### PR DESCRIPTION
## Summary
- close modal before loading data in `applyPlace`
- reopen modal after data loads to avoid DOM patch errors

## Testing
- `cd frontend && npm run lint && npm test`
- `cd backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_686187afadb083308a2b210cebd3ed48