### PR TITLE
Fix stuck loading overlay

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -260,7 +260,8 @@
 
         async function load(preservePositions = false) {
           setLoading(true);
-          const existingPos = {};
+          try {
+            const existingPos = {};
           if (preservePositions) {
             nodes.value.forEach((n) => {
               existingPos[n.id] = { ...n.position };
@@ -381,7 +382,9 @@
           refreshUnions();
           saveTempLayout();
           applyFilters();
+        } finally {
           setLoading(false);
+        }
         }
 
         const children = ref([]);


### PR DESCRIPTION
## Summary
- ensure the loading spinner hides even if data fetch fails

## Testing
- `cd frontend && npm run lint && npm test`
- `cd backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68618a25be408330aa02ce6da845258a