### PR TITLE
Fix initial pan/zoom bug

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -561,6 +561,7 @@
 
         onMounted(async () => {
           await load();
+          await nextTick();
           fitView();
           snapGrid.value = [horizontalGridSize, verticalGridSize];
           snapToGrid.value = true;


### PR DESCRIPTION
## Summary
- wait for DOM before calling `fitView` on mount

## Testing
- `cd frontend && npm run lint`
- `npm test`
- `cd ../backend && npm run lint` *(fails: 'proxyIp' is assigned a value but never used)*
- `npm test` *(fails: People API › creates session from proxy headers)*

------
https://chatgpt.com/codex/tasks/task_e_686198101ae48330a0d6a4d47f558679