### PR TITLE
Fix proxy session test

### DIFF
--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -235,7 +235,8 @@ describe('People API', () => {
       .get('/api/me')
       .set('X-Forwarded-For', '127.0.0.1')
       .set('Remote-User', 'proxyUser')
-      .set('Remote-Email', 'proxy@example.com');
+      .set('X-Remote-Email', 'proxy@example.com')
+      .set('X-Remote-Groups', 'familytree_user');
     expect(res.statusCode).toBe(200);
     expect(res.body.username).toBe('proxyUser');
     expect(res.body.email).toBe('proxy@example.com');


### PR DESCRIPTION
## Summary
- update proxy auth test to send `X-Remote-Groups` and `X-Remote-Email`

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e2ec59108330ab6ad60290ab2edb