### PR TITLE
Fix startup fit to screen issue

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -108,6 +108,11 @@
         );
         const isLoading = ref(true);
         function setLoading(v) { isLoading.value = v; }
+        watch(isLoading, (v) => {
+          if (!v) {
+            nextTick(() => fitView());
+          }
+        });
         const selected = ref(null);
         const showModal = ref(false);
         const contextMenuVisible = ref(false);
@@ -569,7 +574,6 @@
         onMounted(async () => {
           await load();
           await nextTick();
-          fitView();
           snapGrid.value = [horizontalGridSize, verticalGridSize];
           snapToGrid.value = true;
           updatePrivileges();


### PR DESCRIPTION
## Summary
- trigger `fitView` when loading completes instead of immediately on mount
- remove early `fitView()` call on mounted hook

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a22655a00833092473cd74c5cd866