### PR TITLE
Remove auto fit-to-screen on load

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -108,11 +108,6 @@
         );
         const isLoading = ref(true);
         function setLoading(v) { isLoading.value = v; }
-        watch(isLoading, (v) => {
-          if (!v) {
-            nextTick(() => fitView());
-          }
-        });
         const selected = ref(null);
         const showModal = ref(false);
         const contextMenuVisible = ref(false);


### PR DESCRIPTION
## Summary
- stop calling `fitView()` when page load completes

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a80c22e488330874defc7a792fbea