### PR TITLE
Add user feedback for layout actions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -184,6 +184,15 @@
     body.dark-theme #loadingOverlay {
       background: rgba(0,0,0,0.8);
     }
+    #flashBanner {
+      position: fixed;
+      top: 60px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 1100;
+      min-width: 200px;
+      max-width: 90%;
+    }
     #multiIndicator {
       position: absolute;
       top: 10px;
@@ -311,6 +320,9 @@
       height: 16px;
       fill: currentColor;
       stroke: currentColor;
+    }
+    .icon-button:active {
+      transform: scale(0.95);
     }
     .copy-btn {
       position: absolute;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-tree-frontend",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "vue-argon-theme": "^0.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "scripts": {
     "test": "node ../backend/node_modules/jest/bin/jest.js",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"

--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -95,5 +95,8 @@
   ,"roleAdmin": "Administrator"
   ,"roleUser": "Benutzer"
   ,"resetScores": "Punkte zur\u00fccksetzen"
+  ,"layoutLoaded": "Layout geladen"
+  ,"layoutSaved": "Layout gespeichert"
+  ,"layoutTidied": "Layout aufger\u00e4umt"
   ,"loading": "Wird geladen..."
 }

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -95,5 +95,8 @@
   ,"roleAdmin": "Admin"
   ,"roleUser": "User"
   ,"resetScores": "Reset Scores"
+  ,"layoutLoaded": "Layout loaded"
+  ,"layoutSaved": "Layout saved"
+  ,"layoutTidied": "Layout tidied"
   ,"loading": "Loading..."
 }

--- a/frontend/src/lang/pl.json
+++ b/frontend/src/lang/pl.json
@@ -95,5 +95,8 @@
   ,"roleAdmin": "Administrator"
   ,"roleUser": "U\u017cytkownik"
   ,"resetScores": "Zresetuj punkty"
+  ,"layoutLoaded": "Uklad wczytany"
+  ,"layoutSaved": "Uklad zapisany"
+  ,"layoutTidied": "Uklad uporz\u0105dkowany"
   ,"loading": "Ladowanie..."
 }


### PR DESCRIPTION
## Summary
- show flash banner for layout save/load/tidy
- show loading overlay during long layout updates
- add haptic feedback and button press animation
- update translations for new banner messages
- bump version numbers to 0.1.3

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ad98bffe88330871049a6b59e45fd