### PR TITLE
Add GEDCOM import integration tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-tree-frontend",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "dependencies": {
         "vue-argon-theme": "^0.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "scripts": {
     "test": "node ../backend/node_modules/jest/bin/jest.js",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"

--- a/frontend/test/import.test.js
+++ b/frontend/test/import.test.js
@@ -1,0 +1,92 @@
+/** @jest-environment jsdom */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function mountFlow(options = {}) {
+  const sandbox = {
+    window: { ...window, ...options.windowExtras },
+    document,
+    console,
+    module: { exports: {} },
+    exports: {},
+    Vue: {
+      createApp(opts) { return { mount() { return opts.setup(); } }; },
+      ref: (v) => ({ value: v }),
+      computed: (fn) => ({ value: fn() }),
+      onMounted: () => {},
+      onBeforeUnmount: () => {},
+      watch: () => {},
+      nextTick: (fn) => (fn ? fn() : undefined),
+    },
+  };
+  sandbox.window.VueFlow = {
+    VueFlow: {},
+    MarkerType: { ArrowClosed: 'arrow' },
+    Handle: {},
+    useZoomPanHelper: () => ({ fitView: () => {}, zoomTo: () => {} }),
+    useVueFlow: () => ({ screenToFlowCoordinate: () => ({ x:0,y:0 }), dimensions: { width: 500, height: 500 } }),
+  };
+  sandbox.window.GenerationLayout = { assignGenerations: () => new Map() };
+  sandbox.GenerationLayout = sandbox.window.GenerationLayout;
+  sandbox.fetch = () => Promise.resolve({ ok: true, json: () => ({ nodes: [] }) });
+  vm.createContext(sandbox);
+  if (options.windowExtras) {
+    Object.entries(options.windowExtras).forEach(([k, v]) => {
+      sandbox[k] = v;
+    });
+  }
+  const code = fs.readFileSync(path.join(__dirname, '../flow.js'), 'utf8');
+  vm.runInContext(code, sandbox);
+  const FlowApp = sandbox.module.exports;
+  const app = FlowApp.mount();
+  return { sandbox, app };
+}
+
+function setup(options) {
+  const fetchPeople = jest.fn().mockResolvedValue(options.existing || []);
+  const createPerson = jest.fn().mockResolvedValue({ id: 99 });
+  const updatePerson = jest.fn();
+  const linkSpouse = jest.fn();
+  const windowExtras = {
+    Gedcom: { parseGedcom: jest.fn(() => options.parsed) },
+    Dedupe: { findBestMatch: jest.fn(() => options.match), matchScore: jest.fn() },
+    FrontendApp: {
+      fetchPeople,
+      createPerson,
+      updatePerson,
+      deletePerson: jest.fn(),
+      linkSpouse,
+      fetchSpouses: jest.fn(),
+      deleteSpouse: jest.fn(),
+      clearDatabase: jest.fn(),
+    },
+  };
+  const { app } = mountFlow({ windowExtras });
+  app.gedcomText.value = 'dummy';
+  return { app, fetchPeople, createPerson, updatePerson, linkSpouse, windowExtras };
+}
+
+describe('GEDCOM import', () => {
+  test('shows conflict when duplicate found', async () => {
+    const parsed = { people: [{ gedcomId: '@I1@', firstName: 'Ann', lastName: 'Smith' }], families: [] };
+    const match = { match: { id: 1, firstName: 'Ann', lastName: 'Smith' }, score: 5 };
+    const { app, createPerson } = setup({ parsed, match, existing: [{ id: 1, firstName: 'Ann', lastName: 'Smith' }] });
+    await app.processImport();
+    expect(createPerson).not.toHaveBeenCalled();
+    expect(app.conflicts.value.length).toBe(1);
+    expect(app.showConflict.value).toBe(true);
+    expect(app.showImport.value).toBe(false);
+  });
+
+  test('creates new person when no duplicate', async () => {
+    const parsed = { people: [{ gedcomId: '@I2@', firstName: 'Jane', lastName: 'Doe' }], families: [] };
+    const match = { match: null, score: 0 };
+    const { app, fetchPeople, createPerson } = setup({ parsed, match, existing: [] });
+    await app.processImport();
+    expect(createPerson).toHaveBeenCalledTimes(1);
+    expect(app.showConflict.value).toBe(false);
+    // fetchPeople called once during processImport and again inside load()
+    expect(fetchPeople.mock.calls.length).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary
- test GEDCOM import workflow for duplicates and new persons
- bump backend and frontend versions

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`
- `npm --prefix backend run lint`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68734cc5b1ac8330b254596fc419c4f2