### PR TITLE
Fix recursive Vue updates

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "scripts": {
     "test": "node ../backend/node_modules/jest/bin/jest.js",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"

--- a/frontend/vue-flow-core.iife.js
+++ b/frontend/vue-flow-core.iife.js
@@ -1,5 +1,6 @@
 var VueFlowCore = function(exports, vue) {
   "use strict";
+  let isUpdatingNodeDimensions = false;
   function tryOnScopeDispose(fn) {
     if (vue.getCurrentScope()) {
       vue.onScopeDispose(fn);
@@ -6002,11 +6003,17 @@ Edge: ${id2}`
       }
     };
     const updateNodeDimensions = (updates) => {
+      if (isUpdatingNodeDimensions) {
+        return;
+      }
+      isUpdatingNodeDimensions = true;
       if (!state.vueFlowRef) {
+        isUpdatingNodeDimensions = false;
         return;
       }
       const viewportNode = state.vueFlowRef.querySelector(".vue-flow__transformationpane");
       if (!viewportNode) {
+        isUpdatingNodeDimensions = false;
         return;
       }
       const style = window.getComputedStyle(viewportNode);
@@ -6039,6 +6046,7 @@ Edge: ${id2}`
       if (changes.length) {
         state.hooks.nodesChange.trigger(changes);
       }
+      isUpdatingNodeDimensions = false;
     };
     const nodeSelectionHandler = (nodes, selected) => {
       const nodeIds2 = nodes.map((n) => n.id);


### PR DESCRIPTION
## Summary
- guard `updateNodeDimensions` in vue-flow to stop recursion
- bump backend and frontend versions to 0.1.14

## Testing
- `cd frontend && npm run lint && npm test`
- `cd backend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68738fc708148330a0d92ca55da75e5c