### PR TITLE
Fix missing vendor prefixes

### DIFF
--- a/frontend/assets/fonts/fonts.css
+++ b/frontend/assets/fonts/fonts.css
@@ -33,5 +33,6 @@
   word-wrap: normal;
   direction: ltr;
   -webkit-font-feature-settings: 'liga';
+  font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,6 +26,7 @@
     #page-wrapper { display: flex; flex-direction: column; min-height: calc(var(--vh, 1vh) * 100); }
     #main-content { flex: 1; }
     #top-bar, #footer {
+      -webkit-backdrop-filter: blur(8px);
       backdrop-filter: blur(8px);
       box-shadow: 0 2px 4px rgba(0,0,0,0.1);
       border: none;


### PR DESCRIPTION
## Summary
- add `font-feature-settings` property alongside the webkit-prefixed version
- include `-webkit-backdrop-filter` rule for Safari support

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873a67d8ac88330917ab1e89353e353