### PR TITLE
Fix focused view recursion

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1000,6 +1000,7 @@
         function toggleFocused() {
           if (!window.meNodeId) return;
           focusedView.value = !focusedView.value;
+          applyFocusedView();
         }
 
         function onEdgeClick(evt) {
@@ -1168,12 +1169,7 @@
         watch(showRelatives, (v) => v && refreshI18n());
         watch(showScores, (v) => v && refreshI18n());
 
-        watch(focusedView, () => {
-          applyFocusedView();
-        });
-        watch([nodes, edges], () => {
-          if (focusedView.value) applyFocusedView();
-        }, { deep: true });
+        // focused view is toggled via button, no deep watcher to avoid recursion
 
         watch(
           () => selected.value && selected.value.placeOfBirth,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.13",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-tree-frontend",
-      "version": "0.1.13",
+      "version": "0.1.15",
       "dependencies": {
         "vue-argon-theme": "^0.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "scripts": {
     "test": "node ../backend/node_modules/jest/bin/jest.js",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"


### PR DESCRIPTION
## Summary
- avoid deep watcher recursion by updating view in `toggleFocused`
- remove deep watch in `flow.js`
- bump app version to 0.1.15

## Testing
- `cd backend && npm run lint && npm test`
- `cd frontend && npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873a733adbc8330ba2257e78ccfe689