### PR TITLE
fix: prevent gender switch from breaking node creation

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -932,7 +932,7 @@
         watch(
           () => selected.value,
           () => {
-            if (editing.value && showModal.value && !isNew.value) saveSelected();
+            if (editing.value && showModal.value && !isNew.value && selected.value?.id) saveSelected();
           },
           { deep: true }
         );


### PR DESCRIPTION
Add check for selected.value.id in the watcher to prevent attempting to save persons that don't exist in the database yet. This fixes the issue where changing gender during node creation would trigger a premature save operation before the person is created.

Fixes #336

Generated with [Claude Code](https://claude.ai/code)