### PR TITLE
Fix spouse links self-child issue and add delete icons for relationships

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1605,7 +1605,7 @@
           // Update the selected person's data
           const node = nodes.value.find((n) => n.id === String(selected.value.id));
           if (node) {
-            selected.value = { ...node.data, spouseId: '' };
+            selected.value = { ...node.data };
           }
         }
 
@@ -1616,7 +1616,7 @@
           // Update the selected person's data
           const node = nodes.value.find((n) => n.id === String(selected.value.id));
           if (node) {
-            selected.value = { ...node.data, spouseId: '' };
+            selected.value = { ...node.data };
           }
         }
 

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1398,6 +1398,9 @@
           const tgt = nodes.value.find((n) => n.id === params.target);
           if (!src || !tgt) return;
 
+          // Prevent self-connections
+          if (params.source === params.target) return;
+
           if (
             (sH.includes('left') || sH.includes('right')) &&
             (tH.includes('left') || tH.includes('right'))
@@ -1593,6 +1596,28 @@
           await FrontendApp.updatePerson(child.id, updates);
           await load(true);
           computeChildren(selected.value.id);
+        }
+
+        async function removeFather() {
+          if (!selected.value || !selected.value.fatherId) return;
+          await FrontendApp.updatePerson(selected.value.id, { fatherId: null });
+          await load(true);
+          // Update the selected person's data
+          const node = nodes.value.find((n) => n.id === String(selected.value.id));
+          if (node) {
+            selected.value = { ...node.data, spouseId: '' };
+          }
+        }
+
+        async function removeMother() {
+          if (!selected.value || !selected.value.motherId) return;
+          await FrontendApp.updatePerson(selected.value.id, { motherId: null });
+          await load(true);
+          // Update the selected person's data
+          const node = nodes.value.find((n) => n.id === String(selected.value.id));
+          if (node) {
+            selected.value = { ...node.data, spouseId: '' };
+          }
         }
 
         function refreshUnions() {
@@ -2110,6 +2135,8 @@
           saveNewPerson,
           cancelModal,
           unlinkChild,
+          removeFather,
+          removeMother,
           addChild,
           addSpouse,
         addParent,
@@ -2531,6 +2558,11 @@
                     <strong data-i18n="fatherLabel">Father:</strong>
                     <template v-if="selected.fatherId">
                       <a href="#" @click.prevent="gotoPerson(selected.fatherId)">{{ personName(selected.fatherId) }}</a>
+                      <span class="ml-1" style="cursor: pointer;" @click="removeFather" title="Remove father relationship">
+                        <svg viewBox="0 0 24 24" class="text-danger" style="width: 14px; height: 14px; vertical-align: middle;">
+                          <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+                        </svg>
+                      </span>
                     </template>
                     <template v-else>
                       <span class="ml-1" style="cursor: pointer;" @click="startAddParent('father')">
@@ -2544,6 +2576,11 @@
                     <strong data-i18n="motherLabel">Mother:</strong>
                     <template v-if="selected.motherId">
                       <a href="#" @click.prevent="gotoPerson(selected.motherId)">{{ personName(selected.motherId) }}</a>
+                      <span class="ml-1" style="cursor: pointer;" @click="removeMother" title="Remove mother relationship">
+                        <svg viewBox="0 0 24 24" class="text-danger" style="width: 14px; height: 14px; vertical-align: middle;">
+                          <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+                        </svg>
+                      </span>
                     </template>
                     <template v-else>
                       <span class="ml-1" style="cursor: pointer;" @click="startAddParent('mother')">
@@ -2559,6 +2596,11 @@
                     <ul>
                       <li v-for="c in children" :key="c.id">
                         <a href="#" @click.prevent="gotoPerson(c.id)">{{ personName(c.id) }}</a>
+                        <span class="ml-1" style="cursor: pointer;" @click="unlinkChild(c)" title="Remove child relationship">
+                          <svg viewBox="0 0 24 24" class="text-danger" style="width: 14px; height: 14px; vertical-align: middle;">
+                            <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+                          </svg>
+                        </span>
                       </li>
                     </ul>
                   </div>


### PR DESCRIPTION
- Prevent self-connections in onConnect() function to avoid self-spouse and self-child relationships
- Add removeFather() and removeMother() functions to remove parent relationships
- Add delete icons (red X) next to father, mother, and children relationships in detail modal
- Icons include hover tooltips for better UX

Fixes #335