### PR TITLE
fix: remove unused ''id'' variable in deleteSelected function

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1556,9 +1556,8 @@
 
         async function deleteSelected() {
           if (!selected.value) return;
-          const id = selected.value.id;
           showModal.value = false;
-          await FrontendApp.deletePerson(id);
+          await FrontendApp.deletePerson(selected.value.id);
           selected.value = null;
           await load(true);
         }


### PR DESCRIPTION
Inline the id variable directly into the deletePerson call to fix ESLint no-unused-vars error.