### PR TITLE
fix: recenter union helper node after parent drag

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -82,6 +82,7 @@
           snapToGrid,
           snapGrid,
           viewport,
+          updateNodeInternals,
         } = useVueFlow({ id: 'main-flow' });
         const { fitView, zoomTo } = useZoomPanHelper('main-flow');
         const horizontalGridSize =
@@ -2271,6 +2272,7 @@
                     2 +
                   UNION_Y_OFFSET,
               };
+              updateNodeInternals(helper.id);
 
               const spEdge = edges.value.find(
                 (e) => e.id === `spouse-line-${u.id}`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-tree-frontend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "vue-argon-theme": "^0.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "scripts": {
     "test": "node ../backend/node_modules/jest/bin/jest.js",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"


### PR DESCRIPTION
## Summary
- ensure union helper node repositions when parents are moved so child edges stay aligned
- bump backend and frontend version numbers to 0.1.19

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895bf8a7d7483309ee40bfb35be76d6