### PR TITLE
Investigate iphone page load crash

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,13 @@
   <link rel="stylesheet" href="assets/vendor/flatpickr.min.css">
   <link rel="stylesheet" href="assets/fonts/fonts.css">
   <script src="assets/vendor/flatpickr.min.js"></script>
+  <script>(function(){
+    try {
+      var ua = navigator.userAgent || '';
+      var isIOS = /iP(hone|od|ad)/.test(navigator.platform || '') || (/Mac/.test(ua) && 'ontouchend' in document);
+      if (isIOS) { document.documentElement.classList.add('ios'); }
+    } catch(e) { /* ignore */ }
+  })();</script>
   <style>
     html, body { height: 100%; }
     body { font-family: "Inter", sans-serif; }
@@ -54,6 +61,9 @@
       box-shadow: 0 2px 4px rgba(0,0,0,0.1);
       border: none;
     }
+    /* iOS safe-mode: disable heavy GPU effects that can crash WebKit */
+    .ios #top-bar, .ios #footer, .ios #multiIndicator { -webkit-backdrop-filter: none !important; backdrop-filter: none !important; }
+    .ios body.dark-theme, .ios body.bright-theme { background-attachment: scroll !important; background-image: none !important; }
     body.dark-theme #top-bar,
     body.dark-theme #footer {
       background-color: rgba(30,30,30,0.6);
@@ -314,6 +324,7 @@
       box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
       border: 1px solid rgba(255, 255, 255, 0.1);
     }
+    .ios #flashBanner { -webkit-backdrop-filter: none !important; backdrop-filter: none !important; }
     #multiIndicator {
       position: absolute;
       top: 10px;
@@ -329,6 +340,7 @@
       box-shadow: 0 4px 15px rgba(99, 102, 241, 0.3);
       backdrop-filter: blur(10px);
     }
+    .ios #multiIndicator { -webkit-backdrop-filter: none !important; backdrop-filter: none !important; }
     .modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center; }
     .modal-content {
       padding: 24px;
@@ -340,6 +352,7 @@
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
       backdrop-filter: blur(20px);
     }
+    .ios .modal-content { -webkit-backdrop-filter: none !important; backdrop-filter: none !important; }
     body.dark-theme .modal { background: rgba(0,0,0,0.6); }
     body.bright-theme .modal { background: rgba(0,0,0,0.3); }
     body.dark-theme .modal-content {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,7 +24,14 @@
     try {
       var ua = navigator.userAgent || '';
       var isIOS = /iP(hone|od|ad)/.test(navigator.platform || '') || (/Mac/.test(ua) && 'ontouchend' in document);
-      if (isIOS) { document.documentElement.classList.add('ios'); }
+      var supportsBackdrop = false;
+      try {
+        if (window.CSS && CSS.supports) {
+          supportsBackdrop = CSS.supports('backdrop-filter', 'blur(1px)') || CSS.supports('-webkit-backdrop-filter', 'blur(1px)') || CSS.supports('(backdrop-filter: blur(1px))') || CSS.supports('(-webkit-backdrop-filter: blur(1px))');
+        }
+      } catch(e) { supportsBackdrop = false; }
+      var hasBackdropFilterBug = isIOS && !supportsBackdrop;
+      if (isIOS || !supportsBackdrop || hasBackdropFilterBug) { document.documentElement.classList.add('ios'); }
     } catch(e) { /* ignore */ }
   })();</script>
   <style>
@@ -62,7 +69,7 @@
       border: none;
     }
     /* iOS safe-mode: disable heavy GPU effects that can crash WebKit */
-    .ios #top-bar, .ios #footer, .ios #multiIndicator { -webkit-backdrop-filter: none !important; backdrop-filter: none !important; }
+    .ios #top-bar, .ios #footer, .ios #multiIndicator, .ios #flashBanner, .ios .modal-content { -webkit-backdrop-filter: none !important; backdrop-filter: none !important; }
     .ios body.dark-theme, .ios body.bright-theme { background-attachment: scroll !important; background-image: none !important; }
     body.dark-theme #top-bar,
     body.dark-theme #footer {
@@ -324,7 +331,7 @@
       box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
       border: 1px solid rgba(255, 255, 255, 0.1);
     }
-    .ios #flashBanner { -webkit-backdrop-filter: none !important; backdrop-filter: none !important; }
+
     #multiIndicator {
       position: absolute;
       top: 10px;
@@ -340,7 +347,7 @@
       box-shadow: 0 4px 15px rgba(99, 102, 241, 0.3);
       backdrop-filter: blur(10px);
     }
-    .ios #multiIndicator { -webkit-backdrop-filter: none !important; backdrop-filter: none !important; }
+
     .modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center; }
     .modal-content {
       padding: 24px;
@@ -352,7 +359,7 @@
       box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
       backdrop-filter: blur(20px);
     }
-    .ios .modal-content { -webkit-backdrop-filter: none !important; backdrop-filter: none !important; }
+
     body.dark-theme .modal { background: rgba(0,0,0,0.6); }
     body.bright-theme .modal { background: rgba(0,0,0,0.3); }
     body.dark-theme .modal-content {


### PR DESCRIPTION
Add an iOS safe mode to disable heavy GPU effects, preventing intermittent page crashes on iPhones.

WebKit on iOS is known to intermittently crash tabs when rendering complex GPU-intensive effects like `backdrop-filter` blurs and `background-attachment: fixed` with layered images, especially under low-memory conditions or during long paint cycles. This change mitigates these crashes by disabling such effects on iOS devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-5776077c-73b8-465a-a4f0-b86d24d20ee7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5776077c-73b8-465a-a4f0-b86d24d20ee7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

