### PR TITLE
Add leaderboard point explanation legend

### DIFF
--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -2896,6 +2896,15 @@
                 </tr>
               </tbody>
             </table>
+            <div class="mt-3 p-3 bg-light rounded">
+              <h6 data-i18n="pointsLegend">How to earn points:</h6>
+              <div class="small">
+                <div data-i18n="newPersonPoints">• Add new person: 5 points</div>
+                <div data-i18n="editPersonPoints">• Edit existing person: 1-2 points per field</div>
+                <div data-i18n="newInfoPoints">  - Adding new information: 2 points</div>
+                <div data-i18n="updateInfoPoints">  - Updating existing information: 1 point</div>
+              </div>
+            </div>
             <div class="text-right mt-2">
               <button v-if="admin" class="btn btn-danger btn-sm mr-2" @click="resetScores" data-i18n="resetScores">Reset</button>
               <button class="btn btn-primary btn-sm" @click="showScores = false" data-i18n="close">Close</button>

--- a/frontend/src/lang/de.json
+++ b/frontend/src/lang/de.json
@@ -106,4 +106,9 @@
   ,"processingLargeDataset": "Verarbeite {count} Knoten, bitte warten..."
   ,"defineMeFirst": "Bitte zuerst einen Me-Knoten festlegen"
   ,"personsHidden": "Personen ausgeblendet"
+  ,"pointsLegend": "Wie man Punkte sammelt:"
+  ,"newPersonPoints": "• Neue Person hinzufügen: 5 Punkte"
+  ,"editPersonPoints": "• Vorhandene Person bearbeiten: 1-2 Punkte pro Feld"
+  ,"newInfoPoints": "  - Neue Informationen hinzufügen: 2 Punkte"
+  ,"updateInfoPoints": "  - Vorhandene Informationen aktualisieren: 1 Punkt"
 }

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -106,4 +106,9 @@
   ,"processingLargeDataset": "Processing {count} nodes, please wait..."
   ,"defineMeFirst": "Please define a me-node first"
   ,"personsHidden": "persons hidden"
+  ,"pointsLegend": "How to earn points:"
+  ,"newPersonPoints": "• Add new person: 5 points"
+  ,"editPersonPoints": "• Edit existing person: 1-2 points per field"
+  ,"newInfoPoints": "  - Adding new information: 2 points"
+  ,"updateInfoPoints": "  - Updating existing information: 1 point"
 }

--- a/frontend/src/lang/hu.json
+++ b/frontend/src/lang/hu.json
@@ -105,6 +105,11 @@
   "loading": "Betöltés...",
   "processingLargeDataset": "A(z) {count} csomópont feldolgozása, kérem várjon...",
   "defineMeFirst": "Először határozz meg egy saját csomópontot",
-  "personsHidden": "személy elrejtve"
+  "personsHidden": "személy elrejtve",
+  "pointsLegend": "Hogyan szerezhetsz pontokat:",
+  "newPersonPoints": "• Új személy hozzáadása: 5 pont",
+  "editPersonPoints": "• Meglévő személy szerkesztése: 1-2 pont mezőnként",
+  "newInfoPoints": "  - Új információk hozzáadása: 2 pont",
+  "updateInfoPoints": "  - Meglévő információk frissítése: 1 pont"
 }
 

--- a/frontend/src/lang/pl.json
+++ b/frontend/src/lang/pl.json
@@ -106,4 +106,9 @@
   ,"processingLargeDataset": "Przetwarzanie {count} wezlow, prosze czekac..."
   ,"defineMeFirst": "Najpierw zdefiniuj wezel 'me'"
   ,"personsHidden": "os\u00f3b ukrytych"
+  ,"pointsLegend": "Jak zdobywac punkty:"
+  ,"newPersonPoints": "• Dodaj nowa osobe: 5 punktow"
+  ,"editPersonPoints": "• Edytuj istniejaca osobe: 1-2 punkty za pole"
+  ,"newInfoPoints": "  - Dodawanie nowych informacji: 2 punkty"
+  ,"updateInfoPoints": "  - Aktualizacja istniejacych informacji: 1 punkt"
 }


### PR DESCRIPTION
Add a multi-language legend to the leaderboard view explaining how points are earned for adding new people and editing existing ones.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c07d03d-670f-4170-b0f8-cff13ee3fbe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c07d03d-670f-4170-b0f8-cff13ee3fbe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

