### PR TITLE
Optimize search initialization to improve load time

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -208,7 +208,7 @@
 
         const scheduleSearchRefresh = debounce(() => {
           if (window.SearchApp && typeof window.SearchApp.refresh === 'function') {
-            window.SearchApp.refresh();
+            window.SearchApp.refresh(peopleState.value);
           }
         }, 500);
 
@@ -810,7 +810,7 @@
           await load(preservePositions);
           // Refresh search data to keep it in sync with node changes
           if (window.SearchApp && typeof window.SearchApp.refresh === 'function') {
-            await window.SearchApp.refresh();
+            await window.SearchApp.refresh(peopleState.value);
           }
         }
 
@@ -825,6 +825,9 @@
           }
           const people = await FrontendApp.fetchPeople();
           syncPeopleState(people);
+          if (window.SearchApp && typeof window.SearchApp.setPeople === 'function') {
+            window.SearchApp.setPeople(people);
+          }
           
           // Show progress for large datasets
           if (people.length > 1000) {
@@ -2251,7 +2254,7 @@
           
           // Refresh search data so all deleted people are removed from search
           if (window.SearchApp && typeof window.SearchApp.refresh === 'function') {
-            await window.SearchApp.refresh();
+            await window.SearchApp.refresh(peopleState.value);
           }
         }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-tree-frontend",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "vue-argon-theme": "^0.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "scripts": {
     "test": "jest",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"

--- a/frontend/test/search.fuse.test.js
+++ b/frontend/test/search.fuse.test.js
@@ -8,9 +8,8 @@ describe('Search with/without Fuse', () => {
 
   test('works without Fuse by not crashing and showing no results', async () => {
     // No global.Fuse
-    global.fetch = jest.fn().mockResolvedValue({ json: () => [] });
     const SearchApp = require('../search.js');
-    await SearchApp.init();
+    await SearchApp.init({ people: [] });
     const overlay = document.getElementById('search-overlay');
     const input = overlay.querySelector('#search-input');
     input.value = 'anything';
@@ -20,10 +19,13 @@ describe('Search with/without Fuse', () => {
   });
 
   test('works with Fuse and returns matches', async () => {
-    global.fetch = jest.fn().mockResolvedValue({ json: () => [{ id: 1, firstName: 'Alpha', lastName: 'Beta' }] });
-    global.Fuse = class { constructor(list){ this.list=list; } search(q){ return this.list.filter(p => (p.firstName+" "+p.lastName).toLowerCase().includes(q.toLowerCase())).map(item=>({item})); } };
+    const data = [{ id: 1, firstName: 'Alpha', lastName: 'Beta' }];
+    global.Fuse = class {
+      constructor(list){ this.list=list; }
+      search(q){ return this.list.filter(p => (p.firstName+" "+p.lastName).toLowerCase().includes(q.toLowerCase())).map(item=>({item})); }
+    };
     const SearchApp = require('../search.js');
-    await SearchApp.init();
+    await SearchApp.init({ people: data });
     const overlay = document.getElementById('search-overlay');
     const input = overlay.querySelector('#search-input');
     input.value = 'alpha';

--- a/frontend/test/search.test.js
+++ b/frontend/test/search.test.js
@@ -5,24 +5,22 @@ let SearchApp;
 describe('SearchApp', () => {
   beforeEach(async () => {
     jest.resetModules();
-    global.fetch = jest.fn().mockResolvedValue({
-      json: () => [
-        {
-          id: 1,
-          firstName: 'John',
-          lastName: 'Doe',
-          dateOfBirth: '1900-01-01',
-          dateOfDeath: '1980-01-01',
-        },
-        {
-          id: 2,
-          firstName: 'Jane',
-          lastName: 'Smith',
-          dateOfBirth: '1905-05-10',
-          dateOfDeath: '1990-05-10',
-        },
-      ],
-    });
+    const people = [
+      {
+        id: 1,
+        firstName: 'John',
+        lastName: 'Doe',
+        dateOfBirth: '1900-01-01',
+        dateOfDeath: '1980-01-01',
+      },
+      {
+        id: 2,
+        firstName: 'Jane',
+        lastName: 'Smith',
+        dateOfBirth: '1905-05-10',
+        dateOfDeath: '1990-05-10',
+      },
+    ];
     global.Fuse = class {
       constructor(list) {
         this.list = list;
@@ -36,7 +34,7 @@ describe('SearchApp', () => {
     };
     SearchApp = require('../search.js');
     document.body.innerHTML = '';
-    await SearchApp.init();
+    await SearchApp.init({ people });
   });
 
   test('creates overlay and populates results', () => {


### PR DESCRIPTION
## Summary
- refactor the frontend search module to defer Fuse index construction, use a lightweight fallback matcher, and accept shared people data from the flow app
- update the flow renderer to share freshly loaded people with the search module and reuse local state when refreshing search data
- adjust search-related tests to work with the new initialization flow and bump backend/frontend package versions to 0.1.20

## Testing
- npm run lint (backend)
- npm test (backend)
- npm run lint (frontend)
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68ceec4c68308330a4bee14507c174c7