### PR TITLE
Ensure relatives view auto-fits newly loaded segments

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -85,6 +85,7 @@
           updateNodePositions,
         } = useVueFlow({ id: 'main-flow' });
         const { fitView, zoomTo } = useZoomPanHelper('main-flow');
+        const { fitView: fitRelativesView } = useZoomPanHelper('relatives-flow');
         const horizontalGridSize =
           (window.AppConfig &&
             (AppConfig.horizontalGridSize || AppConfig.gridSize)) ||
@@ -1048,6 +1049,18 @@
           hiddenCount.value = hiddenNodeCount;
         }
 
+        function ensureRelativesFit() {
+          nextTick(() => {
+            if (!showRelatives.value) return;
+            if (typeof fitRelativesView !== 'function') return;
+            try {
+              fitRelativesView({ padding: 0.15 });
+            } catch (err) {
+              console.warn('Failed to fit relatives view', err);
+            }
+          });
+        }
+
         function computeRelatives() {
           if (!relativesRoot) return;
           const mode = relativesMode.value;
@@ -1119,6 +1132,7 @@
           tidySubtree(newNodes);
           relativesNodes.value = newNodes;
           relativesEdges.value = newEdges;
+          ensureRelativesFit();
         }
 
         function tidySubtree(list) {
@@ -1186,6 +1200,7 @@
 
         function tidyRelatives() {
           tidySubtree(relativesNodes.value);
+          ensureRelativesFit();
         }
 
         async function onNodeClick(evt) {
@@ -1741,6 +1756,7 @@
           relativesMode.value = 'both';
           computeRelatives();
           showRelatives.value = true;
+          ensureRelativesFit();
         }
 
         async function fetchScore() {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "scripts": {
     "test": "node ../backend/node_modules/jest/bin/jest.js",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"


### PR DESCRIPTION
## Summary
- ensure the relatives modal refits the viewport whenever new nodes/edges are generated so additional segments appear immediately
- trigger a refit after tidy-up operations and the initial open of the relatives view to keep the entire tree visible
- bump frontend and backend package versions to 0.1.19

## Testing
- npm run lint (backend)
- npm test -- --watch=false (backend)
- npm run lint (frontend)
- npm test -- --watch=false (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68e01922cda08330b35505225b482655