### PR TITLE
Handle descendants with incomplete parent data

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",


### PR DESCRIPTION
## Summary
- ensure the export descendants builder groups children by either parent and adds a fallback relationship when a partner is unknown
- add regression coverage for descendants that lack complete parent links
- bump the backend package version to 0.1.31

## Testing
- npm run lint (backend)
- CI=1 npm test (backend)
- npm run lint (frontend)
- CI=1 npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68e18a50ee40833088d360d4e75ba9bc