### PR TITLE
Fix GeoNames cache handling for empty results

### DIFF
--- a/backend/src/services/geonames.js
+++ b/backend/src/services/geonames.js
@@ -32,7 +32,7 @@ async function geonamesPostalCode(lat, lng, cc) {
   if (!geonamesEnabled) return null;
   const key = `gnzip:${lat}:${lng}:${cc}`;
   const cached = await cache.get(key);
-  if (cached !== null) return cached;
+  if (cached !== null && typeof cached !== 'undefined') return cached;
   const url =
     `http://api.geonames.org/findNearbyPostalCodesJSON?lat=${lat}&lng=${lng}` +
     (cc ? `&country=${cc}` : '') +
@@ -73,7 +73,7 @@ async function geonamesSuggest(query, lang = 'en', cc = '') {
   const hash = crypto.createHash('sha1').update((q + lang + cc).toLowerCase()).digest('hex');
   const key = `gn:${hash}`;
   const cached = await cache.get(key);
-  if (cached) return cached;
+  if (cached !== null && typeof cached !== 'undefined') return cached;
   const encoded = encodeURIComponent(q).replace(/-/g, '%2D');
   const queryParam = q.length < 4 ? `name_startsWith=${encoded}` : `q=${encoded}&fuzzy=0.8`;
   const url = `http://api.geonames.org/searchJSON?${queryParam}`

--- a/backend/test/services.test.js
+++ b/backend/test/services.test.js
@@ -45,3 +45,18 @@ test('geonamesSuggest sanitizes input and caches', async () => {
   expect(callsToSearch).toBe(1);
   global.fetch = origFetch;
 });
+
+test('geonamesSuggest caches empty results to avoid duplicate requests', async () => {
+  const origFetch = global.fetch;
+  const payload = { geonames: [] };
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => payload });
+  const first = await geonames.geonamesSuggest('Some Unknown Place', 'en');
+  expect(Array.isArray(first)).toBe(true);
+  expect(first.length).toBe(0);
+  const second = await geonames.geonamesSuggest('some unknown place', 'en');
+  expect(Array.isArray(second)).toBe(true);
+  expect(second.length).toBe(0);
+  const callsToSearch = global.fetch.mock.calls.filter(([url]) => /searchJSON\?/.test(url)).length;
+  expect(callsToSearch).toBe(1);
+  global.fetch = origFetch;
+});


### PR DESCRIPTION
## Summary
- update GeoNames cache lookups to explicitly check for null/undefined so empty results reuse the cache
- ensure the postal-code lookup uses the same comparison convention for consistency
- add a regression test proving that empty GeoNames search results trigger only one HTTP request

## Testing
- npm run lint (backend)
- npm test (backend)
- npm run lint (frontend)
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68e1893654448330adae09bc567a606b