### PR TITLE
Improve node change handling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -2687,7 +2687,10 @@
         }
 
         async function handleNodesChange(changes) {
-          const removed = (changes || []).filter((c) => c.type === 'remove');
+          const list = Array.isArray(changes) ? changes : [];
+          if (!list.length) return;
+
+          const removed = list.filter((c) => c.type === 'remove');
           for (const r of removed) {
             if (!/^\d+$/.test(r.id)) continue;
             try {
@@ -2696,9 +2699,17 @@
               console.error('Failed to delete person', r.id, e);
             }
           }
-          if (removed.length) {
+
+          const hasNonRemoveChanges = list.some((c) => c.type !== 'remove');
+          if (hasNonRemoveChanges) {
+            rebuildNodeMap();
+            nextTick(() => {
+              refreshUnions();
+            });
+          }
+
+          if (removed.length || hasNonRemoveChanges) {
             markSpatialIndexDirty();
-            rebuildSpatialIndex();
           }
         }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-tree-frontend",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "dependencies": {
         "vue-argon-theme": "^0.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "scripts": {
     "test": "jest",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"


### PR DESCRIPTION
## Summary
- ensure Flow node change handler keeps caches and unions in sync for non-remove updates
- mark the spatial index dirty lazily and refresh unions after Vue's next tick
- bump backend and frontend package versions to 0.1.33

## Testing
- npm run lint (backend)
- npm test (backend)
- npm run lint (frontend)
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68e2c596e1b88330aae875fb8546604f