### PR TITLE
Set ancestor hints for spouses in tree segments

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-tree-frontend",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "dependencies": {
         "vue-argon-theme": "^0.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "scripts": {
     "test": "jest",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"


### PR DESCRIPTION
## Summary
- mark descendant segments so spouses and descendants with unseen parents expose hasMoreAncestors hints
- add a backend test covering the new ancestor hint behavior
- bump backend and frontend package versions to 0.1.34

## Testing
- `cd backend && npm run lint`
- `cd backend && npm test -- --runInBand --watch=false`
- `cd frontend && npm run lint`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e2ce85a17083308915174dff6fb34c