### PR TITLE
Fix viewport watcher to trigger segment autoload

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1650,12 +1650,14 @@
           updatePrivileges();
           updateGridSize(viewport.value.zoom || 1);
           watch(
-            viewport,
-            (v) => {
-              updateGridSize(v.zoom);
-              scheduleSegmentAutoload();
+            () => {
+              const vp = viewport.value || {};
+              return [vp.x ?? 0, vp.y ?? 0, vp.zoom ?? 1];
             },
-            { deep: true }
+            ([, , zoom]) => {
+              updateGridSize(zoom ?? 1);
+              scheduleSegmentAutoload();
+            }
           );
           window.addEventListener('keydown', handleKeydown);
           window.addEventListener('keyup', handleKeyup);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-tree-frontend",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "vue-argon-theme": "^0.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "scripts": {
     "test": "jest",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"


### PR DESCRIPTION
## Summary
- track the VueFlow viewport transform reactively so grid updates and autoload scheduling run after panning
- ensure grid recalculation and segment autoload scheduling fire on viewport changes
- bump backend and frontend package versions to 0.1.35

## Testing
- cd backend && npm run lint
- cd backend && npm test
- cd frontend && npm run lint
- cd frontend && npm test

------
https://chatgpt.com/codex/tasks/task_e_68e40ac044ec83309aa8ddbe09edfb12