### PR TITLE
Flag boundary descendants for segment hints

### DIFF
--- a/backend/src/routes/export.js
+++ b/backend/src/routes/export.js
@@ -221,6 +221,11 @@ function flattenDescendants(node, options, peopleMap, metaMap, depth = 0, visite
     const children = Array.isArray(rel.children) ? rel.children : [];
     if (children.length && depth + 1 === options.maxDepth) {
       hasHiddenDescendants = true;
+      for (const child of children) {
+        if (!child || !child.id) continue;
+        const childMeta = ensureMeta(metaMap, child.id);
+        childMeta.hasMoreDescendants = true;
+      }
     }
     if (depth === options.maxDepth) {
       if (children.some((c) => c && c.id)) {


### PR DESCRIPTION
## Summary
- mark depth-limited descendant children so their segment hints advertise more descendants
- extend /api/tree/:id/segment tests to cover deeper descendant scenarios and updated hints

## Testing
- `cd backend && npm run lint`
- `cd backend && npm test -- --runInBand`
- `cd frontend && npm run lint`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e560b5285883309a7ae42377db01dd