### PR TITLE
Fix viewport autoload watcher scheduling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-backend",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/frontend/flow.js
+++ b/frontend/flow.js
@@ -1650,14 +1650,22 @@
           updatePrivileges();
           updateGridSize(viewport.value.zoom || 1);
           watch(
+            () => (viewport.value && viewport.value.zoom) ?? 1,
+            (zoom) => {
+              updateGridSize(zoom ?? 1);
+            },
+            { immediate: true }
+          );
+
+          watch(
             () => {
               const vp = viewport.value || {};
               return [vp.x ?? 0, vp.y ?? 0, vp.zoom ?? 1];
             },
-            ([, , zoom]) => {
-              updateGridSize(zoom ?? 1);
+            () => {
               scheduleSegmentAutoload();
-            }
+            },
+            { immediate: false }
           );
           window.addEventListener('keydown', handleKeydown);
           window.addEventListener('keyup', handleKeyup);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "family-tree-frontend",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "dependencies": {
         "vue-argon-theme": "^0.1.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-frontend",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "scripts": {
     "test": "jest",
     "lint": "eslint app.js flow.js src/utils/exportSvg.js src/utils/assignGenerations.js src/utils/gedcom.js test/**/*.js"


### PR DESCRIPTION
## Summary
- adjust the viewport watchers so zoom updates refresh the grid while autoloading reacts to position changes
- bump the backend and frontend package versions to 0.1.36

## Testing
- npm run lint (backend)
- CI=true npm test (backend)
- npm run lint (frontend)
- npm test (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68e5609089e083308cd19509dabe156d